### PR TITLE
fix failure on merge-base

### DIFF
--- a/packages/utils/src/build-context.js
+++ b/packages/utils/src/build-context.js
@@ -132,7 +132,7 @@ function getAncestorHashForMaster(hash = 'HEAD') {
  * @return {string}
  */
 function getAncestorHashForBranch(hash = 'HEAD') {
-  const result = childProcess.spawnSync('git', ['merge-base', hash, 'master'], {
+  const result = childProcess.spawnSync('git', ['merge-base', hash, 'origin/master'], {
     encoding: 'utf8',
   });
 


### PR DESCRIPTION
repro

```sh
mkdir blah
cd blah
git init
git remote add origin git@github.com:exterkamp/lighthouse-ci-action.git
git -c http.extraheader="AUTHORIZATION: basic ***" fetch --tags --prune --progress --no-recurse-submodules origin "+refs/heads/*:refs/remotes/origin/*"
git checkout --progress --force f2892d1121a20ba2ec047057e5351fdff7fa4905
```

```sh
git merge-base HEAD master
# fatal: Not a valid object name master
```
