### PR TITLE
git short hash of 7

### DIFF
--- a/packages/server/src/ui/routes/build-view/build-hash-selector.jsx
+++ b/packages/server/src/ui/routes/build-view/build-hash-selector.jsx
@@ -134,7 +134,7 @@ const BuildLineItem = props => {
           withDevLine={props.withDevLine}
         />
         <Pill variant={variant} avatar={build}>
-          <span className="build-hash-selector__hash">{build.hash.slice(0, 8)}</span>
+          <span className="build-hash-selector__hash">{build.hash.slice(0, 7)}</span>
         </Pill>{' '}
         <span className="build-hash-selector__commit">{build.commitMessage}</span>
         <span className="build-hash-selector__links">


### PR DESCRIPTION
7 characters is the typical short length (used in github and travis)

admittedly, git uses 9 these days with --short but I think its nicer to use the short one, and to align with github & travis.