### PR TITLE
feat(utils): support ci:client/ci:server rc properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "pg-hstore": "^2.3.3",
     "prettier": "^1.16.4",
     "puppeteer": "^1.18.1",
+    "rimraf": "^3.0.0",
     "sqlite3": "^4.0.6",
     "typescript": "^3.5.3"
   }

--- a/packages/cli/src/autorun/autorun.js
+++ b/packages/cli/src/autorun/autorun.js
@@ -9,7 +9,11 @@ const fs = require('fs');
 const path = require('path');
 const childProcess = require('child_process');
 const _ = require('@lhci/utils/src/lodash.js');
-const {loadRcFile, resolveRcFilePath} = require('@lhci/utils/src/lighthouserc.js');
+const {
+  loadRcFile,
+  flattenRcToConfig,
+  resolveRcFilePath,
+} = require('@lhci/utils/src/lighthouserc.js');
 
 const BUILD_DIR_PRIORITY = [
   // explicitly a dist version of the site, highly likely to be production assets
@@ -95,8 +99,7 @@ function getOverrideArgsForCommand(command) {
 async function runCommand(options) {
   const rcFilePath = resolveRcFilePath(options.config);
   const rcFile = rcFilePath && loadRcFile(rcFilePath);
-  if (rcFile && !rcFile.ci) throw new Error('RC file did not contain a root-level "ci" property');
-  const ciConfiguration = (rcFile && rcFile.ci) || {};
+  const ciConfiguration = rcFile ? flattenRcToConfig(rcFile) : {};
   _.merge(ciConfiguration, _.pick(options, ['assert', 'collect', 'upload']));
 
   const defaultFlags = options.config ? [`--config=${options.config}`] : [];

--- a/packages/cli/test/assert.test.js
+++ b/packages/cli/test/assert.test.js
@@ -28,7 +28,7 @@ describe('Lighthouse CI assert CLI', () => {
 
   beforeAll(() => {
     const lighthouseciDir = path.join(fixtureDir, '.lighthouseci');
-    if (!fs.existsSync(lighthouseciDir)) fs.mkdirSync(lighthouseciDir);
+    if (!fs.existsSync(lighthouseciDir)) fs.mkdirSync(lighthouseciDir, {recursive: true});
     const fakeLhrPath = path.join(lighthouseciDir, 'lhr-12345.json');
     const fakeLhr = {categories: {}, audits: {}};
     fakeLhr.categories.pwa = {score: 0};

--- a/packages/cli/test/assert.test.js
+++ b/packages/cli/test/assert.test.js
@@ -9,6 +9,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const rimraf = require('rimraf');
 const fullPreset = require('@lhci/utils/src/presets/all.js');
 const {runCLI} = require('./test-utils.js');
 
@@ -28,6 +29,7 @@ describe('Lighthouse CI assert CLI', () => {
 
   beforeAll(() => {
     const lighthouseciDir = path.join(fixtureDir, '.lighthouseci');
+    if (fs.existsSync(lighthouseciDir)) rimraf.sync(lighthouseciDir);
     if (!fs.existsSync(lighthouseciDir)) fs.mkdirSync(lighthouseciDir, {recursive: true});
     const fakeLhrPath = path.join(lighthouseciDir, 'lhr-12345.json');
     const fakeLhr = {categories: {}, audits: {}};
@@ -43,8 +45,8 @@ describe('Lighthouse CI assert CLI', () => {
   it('should run the recommended preset', () => {
     const result = run([`--preset=lighthouse:recommended`]);
     expect(result.status).toEqual(1);
-    expect(result.warnings).toHaveLength(19);
-    expect(result.failures).toHaveLength(91);
+    expect(result.warnings).toHaveLength(17);
+    expect(result.failures).toHaveLength(79);
     expect(result.failures).toContain('deprecations failure');
     expect(result.failures).toContain('viewport failure');
   });
@@ -52,8 +54,8 @@ describe('Lighthouse CI assert CLI', () => {
   it('should run the no-pwa preset', () => {
     const result = run([`--preset=lighthouse:no-pwa`]);
     expect(result.status).toEqual(1);
-    expect(result.warnings).toHaveLength(15);
-    expect(result.failures).toHaveLength(74);
+    expect(result.warnings).toHaveLength(14);
+    expect(result.failures).toHaveLength(70);
     expect(result.failures).toContain('deprecations failure');
     expect(result.failures).not.toContain('viewport failure');
   });

--- a/packages/utils/src/lighthouserc.js
+++ b/packages/utils/src/lighthouserc.js
@@ -100,7 +100,7 @@ function hasOptedOutOfRcDetection(argv = process.argv, env = process.env) {
  * @return {LHCI.YargsOptions}
  */
 function convertRcFileToYargsOptions(rcFile, pathToRcFile) {
-  const {ci = {}} = rcFile;
+  const ci = flattenRcToConfig(rcFile);
   /** @type {LHCI.YargsOptions} */
   let merged = {...ci.assert, ...ci.collect, ...ci.upload, ...ci.server};
   if (ci.extends) {
@@ -110,6 +110,20 @@ function convertRcFileToYargsOptions(rcFile, pathToRcFile) {
   }
 
   return merged;
+}
+
+/**
+ *
+ * @param {LHCI.LighthouseRc} rc
+ * @return {LHCI.LighthouseCiConfig}
+ */
+function flattenRcToConfig(rc) {
+  return {
+    ...(rc.ci || {}),
+    ...(rc.lhci || {}),
+    ..._.omit(rc['ci:client'] || {}, ['server']),
+    ..._.pick(rc['ci:server'] || {}, ['server']),
+  };
 }
 
 /** @param {string|undefined} pathToRcFile */
@@ -123,5 +137,6 @@ module.exports = {
   loadAndParseRcFile,
   findRcFile,
   resolveRcFilePath,
+  flattenRcToConfig,
   hasOptedOutOfRcDetection,
 };

--- a/types/lighthouserc.d.ts
+++ b/types/lighthouserc.d.ts
@@ -6,14 +6,19 @@
 
 declare global {
   namespace LHCI {
+    export interface LighthouseCiConfig {
+      extends?: string;
+      assert?: Partial<AssertCommand.Options>;
+      collect?: Partial<CollectCommand.Options>;
+      upload?: Partial<UploadCommand.Options>;
+      server?: Partial<ServerCommand.Options>;
+    }
+
     export interface LighthouseRc {
-      ci?: {
-        extends?: string;
-        assert?: Partial<AssertCommand.Options>;
-        collect?: Partial<CollectCommand.Options>;
-        upload?: Partial<UploadCommand.Options>;
-        server?: Partial<ServerCommand.Options>;
-      };
+      ci?: LighthouseCiConfig;
+      lhci?: LighthouseCiConfig;
+      'ci:client'?: LighthouseCiConfig;
+      'ci:server'?: LighthouseCiConfig;
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12300,6 +12300,13 @@ rimraf@2.6.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.0.tgz#614176d4b3010b75e5c390eb0ee96f6dc0cebb9b"
+  integrity sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"


### PR DESCRIPTION
The last remaining item in #48, `ci:client`/`ci:server` support.

closes #48 