### PR TITLE
fix(cli): resource-summary output and budget

### DIFF
--- a/packages/cli/src/assert/assert.js
+++ b/packages/cli/src/assert/assert.js
@@ -37,11 +37,6 @@ function readBudgets(budgetsFile) {
   return JSON.parse(fs.readFileSync(fullyResolvedPath, 'utf8'));
 }
 
-/** @param {number} value @return {string} */
-function getBytesValueOutput(value) {
-  return `${(value / 1024).toFixed(2)} KB`;
-}
-
 /**
  * @param {LHCI.AssertCommand.Options} options
  * @return {Promise<void>}
@@ -81,12 +76,6 @@ async function runCommand(options) {
       const idPart = `${log.bold}${result.auditId}${log.reset}`;
       const propertyPart = result.auditProperty ? `.${result.auditProperty}` : '';
       const namePart = `${log.bold}${result.name}${log.reset}`;
-      const isResourceSizes = result.auditId === 'resource-summary';
-      const actual = isResourceSizes ? getBytesValueOutput(result.actual) : result.actual;
-      const expected = isResourceSizes ? getBytesValueOutput(result.expected) : result.expected;
-      const values = isResourceSizes
-        ? result.values.map(value => getBytesValueOutput(value))
-        : result.values;
 
       const auditTitlePart = result.auditTitle || '';
       const documentationPart = result.auditDocumentationLink
@@ -100,9 +89,9 @@ async function runCommand(options) {
 
       process.stderr.write(`
   ${icon} ${idPart}${propertyPart} ${label} for ${namePart} assertion${humanFriendlyParts}
-        expected: ${result.operator}${log.greenify(expected)}
-           found: ${log.redify(actual)}
-      ${log.dim}all values: ${values.join(', ')}${log.reset}\n\n`);
+        expected: ${result.operator}${log.greenify(result.expected)}
+           found: ${log.redify(result.actual)}
+      ${log.dim}all values: ${result.values.join(', ')}${log.reset}\n\n`);
     }
   }
 

--- a/packages/cli/src/assert/assert.js
+++ b/packages/cli/src/assert/assert.js
@@ -37,6 +37,11 @@ function readBudgets(budgetsFile) {
   return JSON.parse(fs.readFileSync(fullyResolvedPath, 'utf8'));
 }
 
+/** @param {number} value @return {string} */
+function getBytesValueOutput(value) {
+  return `${(value / 1024).toFixed(2)} KB`;
+}
+
 /**
  * @param {LHCI.AssertCommand.Options} options
  * @return {Promise<void>}
@@ -76,6 +81,12 @@ async function runCommand(options) {
       const idPart = `${log.bold}${result.auditId}${log.reset}`;
       const propertyPart = result.auditProperty ? `.${result.auditProperty}` : '';
       const namePart = `${log.bold}${result.name}${log.reset}`;
+      const isResourceSizes = result.auditId === 'resource-summary';
+      const actual = isResourceSizes ? getBytesValueOutput(result.actual) : result.actual;
+      const expected = isResourceSizes ? getBytesValueOutput(result.expected) : result.expected;
+      const values = isResourceSizes
+        ? result.values.map(value => getBytesValueOutput(value))
+        : result.values;
 
       const auditTitlePart = result.auditTitle || '';
       const documentationPart = result.auditDocumentationLink
@@ -89,9 +100,9 @@ async function runCommand(options) {
 
       process.stderr.write(`
   ${icon} ${idPart}${propertyPart} ${label} for ${namePart} assertion${humanFriendlyParts}
-        expected: ${result.operator}${log.greenify(result.expected)}
-           found: ${log.redify(result.actual)}
-      ${log.dim}all values: ${result.values.join(', ')}${log.reset}\n\n`);
+        expected: ${result.operator}${log.greenify(expected)}
+           found: ${log.redify(actual)}
+      ${log.dim}all values: ${values.join(', ')}${log.reset}\n\n`);
     }
   }
 

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -418,7 +418,7 @@ describe('Lighthouse CI CLI', () => {
              Keep request counts low and transfer sizes small
              Documentation: https://developers.google.com/web/tools/lighthouse/audits/budgets
 
-                expected: <=[32m1[0m
+                expected: <=[32mXXXX[0m
                    found: [31mXXXX[0m
               [2mall values: XXXX, XXXX[0m
 

--- a/packages/utils/src/budgets-converter.js
+++ b/packages/utils/src/budgets-converter.js
@@ -40,7 +40,10 @@ function convertBudgetsToAssertions(budgets) {
     }
 
     for (const {resourceType, budget: maxNumericValue} of budget.resourceSizes || []) {
-      assertions[`resource-summary:${resourceType}:size`] = ['error', {maxNumericValue}];
+      assertions[`resource-summary:${resourceType}:size`] = [
+        'error',
+        {maxNumericValue: maxNumericValue * 1024},
+      ];
     }
 
     assertMatrix.push({

--- a/packages/utils/test/assertions.test.js
+++ b/packages/utils/test/assertions.test.js
@@ -562,7 +562,7 @@ describe('getAllAssertionResults', () => {
             {resourceType: 'font', budget: 1},
             {resourceType: 'third-party', budget: 5},
           ],
-          resourceSizes: [{resourceType: 'document', budget: 400}],
+          resourceSizes: [{resourceType: 'document', budget: 1}],
         },
       ];
 
@@ -596,7 +596,7 @@ describe('getAllAssertionResults', () => {
           actual: 1143,
           auditId: 'resource-summary',
           auditProperty: 'document.size',
-          expected: 400,
+          expected: 1024,
           level: 'error',
           name: 'maxNumericValue',
           operator: '<=',

--- a/packages/utils/test/budgets-converter.test.js
+++ b/packages/utils/test/budgets-converter.test.js
@@ -111,8 +111,8 @@ describe('convertBudgetsToAssertions', () => {
         {
           matchingUrlPattern: '.*',
           assertions: {
-            'resource-summary:script:size': ['error', {maxNumericValue: 123}],
-            'resource-summary:image:size': ['error', {maxNumericValue: 456}],
+            'resource-summary:script:size': ['error', {maxNumericValue: 123 * 1024}],
+            'resource-summary:image:size': ['error', {maxNumericValue: 456 * 1024}],
             'resource-summary:third-party:count': ['error', {maxNumericValue: 10}],
             'resource-summary:total:count': ['error', {maxNumericValue: 100}],
           },
@@ -120,7 +120,7 @@ describe('convertBudgetsToAssertions', () => {
         {
           matchingUrlPattern: 'https?:\\/\\/[^\\/]+\\/second\\-path',
           assertions: {
-            'resource-summary:script:size': ['error', {maxNumericValue: 1000}],
+            'resource-summary:script:size': ['error', {maxNumericValue: 1000 * 1024}],
           },
         },
       ],


### PR DESCRIPTION
Howdy 👋 

Some of the users are running into an issues when failed assertion results for `resource-summary` are inconsistent with budget (for example - https://github.com/treosh/lighthouse-ci-action/issues/13)
E.g. I setup budget for 1KB, actual value is ~17KB. 
What seen in console is something like that:
```
expected: <=1
found: 17387
```

For better UX, I propose smth like we have in LH

```
expected: <=1.00 KB
found: 16.98 KB
```

Here is comparison of logs before and after the proposal:

![image](https://user-images.githubusercontent.com/6231516/68983908-2ae25480-0816-11ea-895b-58baea9fcf55.png)


P.R. Is still draft, if we are ok, I can tune more stuff for that. 

Cheers,
