### PR TITLE
feat(cli): add chrome installations to healthcheck

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@lhci/utils": "0.1.0",
+    "chrome-launcher": "^0.12.0",
     "compression": "^1.7.4",
     "express": "^4.17.1",
     "inquirer": "^6.3.1",
@@ -21,7 +22,7 @@
     "open": "^6.4.0",
     "tmp": "^0.1.0",
     "update-notifier": "^3.0.1",
-    "yargs-parser": "^11.1.1",
-    "yargs": "^12.0.5"
+    "yargs": "^12.0.5",
+    "yargs-parser": "^11.1.1"
   }
 }

--- a/packages/cli/src/healthcheck/healthcheck.js
+++ b/packages/cli/src/healthcheck/healthcheck.js
@@ -5,6 +5,7 @@
  */
 'use strict';
 
+const ChromeLauncher = require('chrome-launcher').Launcher;
 const ApiClient = require('@lhci/utils/src/api-client.js');
 const {loadAndParseRcFile, resolveRcFilePath} = require('@lhci/utils/src/lighthouserc.js');
 const {
@@ -52,6 +53,12 @@ const checks = [
       if (!rcFile) return false;
       return Boolean(loadAndParseRcFile(rcFile));
     },
+  },
+  {
+    label: 'Chrome installation found',
+    failureLabel: 'Chrome installation not found',
+    shouldTest: () => true,
+    test: () => ChromeLauncher.getInstallations().length > 0,
   },
   {
     id: 'githubToken',

--- a/packages/cli/test/autorun-start-server.test.js
+++ b/packages/cli/test/autorun-start-server.test.js
@@ -29,6 +29,7 @@ describe('Lighthouse CI autorun CLI with startServerCommand', () => {
     expect(stdout).toMatchInlineSnapshot(`
       "✅  .lighthouseci/ directory writable
       ⚠️   Configuration file not found
+      ✅  Chrome installation found
       Healthcheck passed!
 
       Started a web server with \\"node autorun-server.js\\"...

--- a/packages/cli/test/autorun-static-dir.test.js
+++ b/packages/cli/test/autorun-static-dir.test.js
@@ -25,6 +25,7 @@ describe('Lighthouse CI autorun CLI', () => {
     expect(stdoutClean).toMatchInlineSnapshot(`
       "✅  .lighthouseci/ directory writable
       ✅  Configuration file found
+      ✅  Chrome installation found
       ⚠️   GitHub token not set
       Healthcheck passed!
 

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -110,6 +110,7 @@ describe('Lighthouse CI CLI', () => {
       expect(stdout).toMatchInlineSnapshot(`
         "✅  .lighthouseci/ directory writable
         ⚠️   Configuration file not found
+        ✅  Chrome installation found
         ⚠️   GitHub token not set
         ✅  Ancestor hash determinable
         ✅  LHCI server reachable
@@ -133,6 +134,7 @@ describe('Lighthouse CI CLI', () => {
       expect(stdout).toMatchInlineSnapshot(`
         "✅  .lighthouseci/ directory writable
         ✅  Configuration file found
+        ✅  Chrome installation found
         ❌  GitHub token not set
         ✅  Ancestor hash determinable
         ✅  LHCI server reachable

--- a/packages/cli/test/healthcheck.test.js
+++ b/packages/cli/test/healthcheck.test.js
@@ -21,6 +21,7 @@ describe('Lighthouse CI healthcheck CLI', () => {
       expect(stdout).toMatchInlineSnapshot(`
         "✅  .lighthouseci/ directory writable
         ✅  Configuration file found
+        ✅  Chrome installation found
         ⚠️   GitHub token not set
         Healthcheck passed!
         "
@@ -38,6 +39,7 @@ describe('Lighthouse CI healthcheck CLI', () => {
       expect(stdout).toMatchInlineSnapshot(`
         "✅  .lighthouseci/ directory writable
         ✅  Configuration file found
+        ✅  Chrome installation found
         ⚠️   GitHub token not set
         Healthcheck passed!
         "
@@ -55,6 +57,7 @@ describe('Lighthouse CI healthcheck CLI', () => {
       expect(stdout).toMatchInlineSnapshot(`
         "✅  .lighthouseci/ directory writable
         ⚠️   Configuration file not found
+        ✅  Chrome installation found
         Healthcheck passed!
         "
       `);
@@ -71,6 +74,7 @@ describe('Lighthouse CI healthcheck CLI', () => {
       expect(stdout).toMatchInlineSnapshot(`
         "✅  .lighthouseci/ directory writable
         ⚠️   Configuration file not found
+        ✅  Chrome installation found
         Healthcheck passed!
         "
       `);
@@ -87,6 +91,7 @@ describe('Lighthouse CI healthcheck CLI', () => {
       expect(stdout).toMatchInlineSnapshot(`
         "✅  .lighthouseci/ directory writable
         ⚠️   Configuration file not found
+        ✅  Chrome installation found
         Healthcheck passed!
         "
       `);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3722,6 +3722,17 @@ chrome-launcher@^0.11.2:
     mkdirp "0.5.1"
     rimraf "^2.6.1"
 
+chrome-launcher@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.12.0.tgz#08db81ef0f7b283c331df2c350e780c38bd0ce3a"
+  integrity sha512-rBUP4tvWToiileDi3UR0SbWKoUoDCYTRmVND2sdoBL1xANBgVz8V9h1yQluj3MEQaBJg0fRw7hW82uOPrJus7A==
+  dependencies:
+    "@types/node" "*"
+    is-wsl "^2.1.0"
+    lighthouse-logger "^1.0.0"
+    mkdirp "0.5.1"
+    rimraf "^2.6.1"
+
 ci-info@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"


### PR DESCRIPTION
common issue is that chrome isn't available on their instance, this adds the check to `healthcheck` to catch it earlier and print a nice message