### PR TITLE
fix (cli): use rc-file if it wasn't found recursively

### DIFF
--- a/packages/cli/src/cli.js
+++ b/packages/cli/src/cli.js
@@ -29,13 +29,11 @@ updateNotifier({pkg}).notify({defer: false});
 /** @return {[string, (path: string) => LHCI.YargsOptions]|[LHCI.YargsOptions]} */
 function createYargsConfigArguments() {
   const simpleArgv = yargsParser(process.argv.slice(2), {envPrefix: 'LHCI'});
-  /** @type {[string, (path: string) => LHCI.YargsOptions]} */
-  const configOption = ['config', loadAndParseRcFile];
   // If they're using the config option or opting out of auto-detection, use the config option.
-  if (simpleArgv.config || hasOptedOutOfRcDetection()) return configOption;
+  if (simpleArgv.config || hasOptedOutOfRcDetection()) return ['config', loadAndParseRcFile];
   const rcFile = findRcFile();
   // If they don't currently have an rc file, use the config option for awareness.
-  if (!rcFile) return configOption;
+  if (!rcFile) return ['rc-file', loadAndParseRcFile];
   return [loadAndParseRcFile(rcFile)];
 }
 


### PR DESCRIPTION
> One more time without issue

So, since we are kinda has advanced usage in Action, `rc-file` has custom name like `lighthouserc_assertions.json` and fails when I upgrated to v0.3.3 - https://github.com/treosh/lighthouse-ci-action/pull/15/checks?check_run_id=307103933

It happens because file can't be found recursively via using[ from cli ](https://github.com/GoogleChrome/lighthouse-ci/blob/v0.3.3/packages/cli/src/cli.js#L36)calling [findRcFile](https://github.com/GoogleChrome/lighthouse-ci/blob/v0.3.3/packages/utils/src/lighthouserc.js#L71), then using `assertCmd.runCommand` it fails because parsed config was not passed.

I'm not 100% it's a correct fix. Here are 2 options for the fix:
1. One in PR
2. Use kinda the same logic as it's used in [autorunCmd.runCommand](https://github.com/GoogleChrome/lighthouse-ci/blob/v0.3.3/packages/cli/src/autorun/autorun.js#L99) for [assertCmd.runCommand](https://github.com/GoogleChrome/lighthouse-ci/blob/v0.3.3/packages/cli/src/assert/assert.js#L44) to get `rc-file` values.

Cheers,