### PR TITLE
feat(cli): add --puppeteer-script flag to collect

### DIFF
--- a/docs/recipes/docker-server/update-dockerhub.sh
+++ b/docs/recipes/docker-server/update-dockerhub.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 CURRENT_VERSION=$(node -e "console.log(require('./package.json').dependencies['@lhci/server'])")
-# NEXT_VERSION=$(yarn info @lhci/server | grep 'latest:' -A 1 | tail -n 1 | grep -o "'.*'" | sed s/\'//g)
-NEXT_VERSION=0.3.3
+NEXT_VERSION=$(yarn info @lhci/server | grep 'latest:' -A 1 | tail -n 1 | grep -o "'.*'" | sed s/\'//g)
 
 if [[ "$CURRENT_VERSION" == "$NEXT_VERSION" ]]; then
   echo "Version is already at $NEXT_VERSION, exiting..."

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,6 +4,14 @@
 
 First, make sure you're using `lhci autorun` or invoking `lhci healthcheck --fatal` in your script. Check the output logs of the healthcheck for anything that's failing and try resolving those problems first using the guide below before filing an issue.
 
+## My page is behind a login. How do I get Lighthouse CI to run on the real app?
+
+You have a couple of options to teach Lighthouse CI how to login to your page.
+
+- [`--collect.puppeteerScript`](./cli.md#using-puppeteer-scripts)
+- [Configure Custom Headers](./configuration.md#page-behind-authentication)
+- [Other Lighthouse Auth Methods](https://github.com/GoogleChrome/lighthouse/blob/v5.6.0/docs/authenticated-pages.md)
+
 ## The GitHub App/LHCI server upload isn't working on PRs from external contributors.
 
 Most CI systems prevent secrets from leaking into the environment of untrusted pull requests from forks. This is a helpful security measure to prevent privileged information from falling into malicious hands.

--- a/packages/cli/src/collect/lighthouse-runner.js
+++ b/packages/cli/src/collect/lighthouse-runner.js
@@ -76,13 +76,14 @@ class LighthouseRunner {
     let stdout = '';
     let stderr = '';
 
+    const env = {...process.env, CHROME_PATH: options.chromePath || process.env.CHROME_PATH};
     const {args, cleanupFn} = LighthouseRunner.computeArgumentsAndCleanup(url, options);
-    const process = childProcess.spawn('node', [LH_CLI_PATH, ...args]);
+    const child = childProcess.spawn('node', [LH_CLI_PATH, ...args], {env});
 
-    process.stdout.on('data', chunk => (stdout += chunk.toString()));
-    process.stderr.on('data', chunk => (stderr += chunk.toString()));
+    child.stdout.on('data', chunk => (stdout += chunk.toString()));
+    child.stderr.on('data', chunk => (stderr += chunk.toString()));
 
-    process.on('exit', code => {
+    child.on('exit', code => {
       cleanupFn();
       if (code === 0) return resolve(stdout);
 

--- a/packages/cli/src/collect/puppeteer-manager.js
+++ b/packages/cli/src/collect/puppeteer-manager.js
@@ -41,9 +41,7 @@ class PuppeteerManager {
   /** @return {Promise<number>} */
   async getBrowserPort() {
     const browser = await this._getBrowser();
-    const [_ = '', port = ''] = browser.wsEndpoint().match(/:(\d+)/) || [];
-    if (!port) throw new Error('Unable to determine port from puppeteer browser');
-    return parseInt(port, 10);
+    return Number(new URL(browser.wsEndpoint()).port);
   }
 
   /**

--- a/packages/cli/src/collect/puppeteer-manager.js
+++ b/packages/cli/src/collect/puppeteer-manager.js
@@ -1,0 +1,64 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const path = require('path');
+
+/** @typedef {(browser: import('puppeteer').Browser, context: {url: string, options: LHCI.CollectCommand.Options}) => void} PuppeteerScript */
+
+class PuppeteerManager {
+  /** @param {LHCI.CollectCommand.Options} options */
+  constructor(options) {
+    this._options = options;
+
+    /** @type {null|import('puppeteer').Browser} */
+    this._browser = null;
+  }
+
+  /** @return {Promise<import('puppeteer').Browser>} */
+  async _getBrowser() {
+    if (!this.isActive()) throw new Error('Should not launch a browser when inactive');
+    if (this._browser) return this._browser;
+
+    // Delay require to only run after user requests puppeteer functionality.
+    const puppeteer = require('puppeteer');
+    this._browser = await puppeteer.launch({
+      pipe: false,
+      executablePath: this._options.chromePath,
+    });
+
+    return this._browser;
+  }
+
+  /** @return {boolean} */
+  isActive() {
+    return !!this._options.puppeteerScript;
+  }
+
+  /** @return {Promise<number>} */
+  async getBrowserPort() {
+    const browser = await this._getBrowser();
+    const [_ = '', port = ''] = browser.wsEndpoint().match(/:(\d+)/) || [];
+    if (!port) throw new Error('Unable to determine port from puppeteer browser');
+    return parseInt(port, 10);
+  }
+
+  /**
+   * @param {string} url
+   * @return {Promise<void>}
+   */
+  async invokePuppeteerScriptForUrl(url) {
+    const scriptPath = this._options.puppeteerScript;
+    if (!scriptPath) return;
+
+    const browser = await this._getBrowser();
+    /** @type {PuppeteerScript} */
+    const script = require(path.join(process.cwd(), scriptPath));
+    await script(browser, {url, options: this._options});
+  }
+}
+
+module.exports = PuppeteerManager;

--- a/packages/cli/test/collect-puppeteer.test.js
+++ b/packages/cli/test/collect-puppeteer.test.js
@@ -1,0 +1,43 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+jest.retryTimes(3);
+
+/* eslint-env jest */
+
+const path = require('path');
+const {runCLI} = require('./test-utils.js');
+
+describe('Lighthouse CI collect CLI with puppeteer', () => {
+  const autorunDir = path.join(__dirname, 'fixtures/puppeteer');
+
+  it('should run lighthouse on an auth page', () => {
+    const {stdout, stderr, status} = runCLI(
+      [
+        'collect',
+        '-n=1',
+        '--url=http://localhost:52426',
+        '--start-server-command=node ./auth-server.js',
+        '--puppeteer-script=./auth-server-script.js',
+      ],
+      {cwd: autorunDir}
+    );
+
+    // The server above will return a 401 Unauthorized when the login script isn't invoked.
+    // 4xx and 5xx status codes cause Lighthouse to exit with 1 and collect to fail.
+    // Just succeeding here is enough to signal that our login script worked.
+    expect(stdout).toMatchInlineSnapshot(`
+      "Started a web server with \\"node ./auth-server.js\\"...
+      Running Lighthouse 1 time(s) on http://localhost:XXXX
+      Run #1...done.
+      Done running Lighthouse!
+      "
+    `);
+    expect(stderr).toMatchInlineSnapshot(`""`);
+    expect(status).toEqual(0);
+  }, 180000);
+});

--- a/packages/cli/test/fixtures/puppeteer/auth-server-script.js
+++ b/packages/cli/test/fixtures/puppeteer/auth-server-script.js
@@ -1,0 +1,12 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/** @param {import('puppeteer').Browser} */
+module.exports = async browser => {
+  const page = await browser.newPage();
+  await page.goto('http://localhost:52426/login');
+};

--- a/packages/cli/test/fixtures/puppeteer/auth-server.js
+++ b/packages/cli/test/fixtures/puppeteer/auth-server.js
@@ -1,0 +1,37 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const express = require('express');
+const app = express();
+app.get('/', (req, res) => {
+  const cookies = (req.header('cookie') || '').match(/\w+=/g) || [];
+  if (!cookies.includes('loggedin=')) {
+    res.status(401);
+    res.send(`<!DOCTYPE html><html>Unauthorized`);
+    return;
+  }
+
+  res.send(`
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>good test page for collect usage</title>
+  </head>
+  <body>
+    test
+  </body>
+</html>
+  `);
+});
+
+app.get('/login', (_, res) => {
+  res.cookie('loggedin', '1', {expires: new Date(Date.now() + 15 * 60e3), httpOnly: true});
+  res.redirect('/');
+});
+
+app.listen(52426, () => process.stdout.write('Listening...'));

--- a/types/collect.d.ts
+++ b/types/collect.d.ts
@@ -42,6 +42,8 @@ declare global {
         url?: string | string[];
         staticDistDir?: string;
         startServerCommand?: string;
+        chromePath?: string;
+        puppeteerScript?: string;
         method: 'node';
         numberOfRuns: number;
         headful: boolean;


### PR DESCRIPTION
closes #89 

Usage looks like:

```
lhci collect \
  --start-server-command="yarn serve" \
  --url=http://localhost:8080/ \
  --puppeteer-script=./path/to/login-with-puppeteer.js
```

**Example `login-with-puppeteer.js`**

```js
/**
 * @param {puppeteer.Browser} browser
 * @param {{url: string, options: LHCI.CollectOptions}} context
 */
module.exports = async (browser, context) => {
  const page = await browser.newPage();
  await page.goto('http://localhost:8080/login');
  await page.type('#username', 'admin');
  await page.type('#password', 'password');
  await page.click('[type="submit"]');
  await page.waitForNavigation();
};
```