### PR TITLE
feat(cli): add --puppeteer-launch-options flag to collect

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -104,23 +104,25 @@ lhci collect --help
 Run Lighthouse and save the results to a local folder
 
 Options:
-  --help                Show help                                      [boolean]
-  --version             Show version number                            [boolean]
-  --config              Path to JSON config file
-  --method                          [string] [choices: "node"] [default: "node"]
-  --headful             Run with a headful Chrome                      [boolean]
-  --additive            Skips clearing of previous collect data        [boolean]
-  --url                 A URL to run Lighthouse on.  You can evaluate multiple
-                        URLs by adding this flag multiple times.
-  --staticDistDir       The build directory where your HTML files to run
-                        Lighthouse on are located.
-  --chromePath          The path to the Chrome or Chromium executable to use for
-                        collection.
-  --puppeteerScript     The path to a script that manipulates the browser with
-                        puppeteer before running Lighthouse, used for auth.
-  --startServerCommand  The command to run to start the server.
-  --settings            The Lighthouse settings and flags to use when collecting
-  --numberOfRuns, -n    The number of times to run Lighthouse.
+  --help                   Show help                                      [boolean]
+  --version                Show version number                            [boolean]
+  --config                 Path to JSON config file
+  --method                             [string] [choices: "node"] [default: "node"]
+  --headful                Run with a headful Chrome                      [boolean]
+  --additive               Skips clearing of previous collect data        [boolean]
+  --url                    A URL to run Lighthouse on.  You can evaluate multiple
+                           URLs by adding this flag multiple times.
+  --staticDistDir          The build directory where your HTML files to run
+                           Lighthouse on are located.
+  --chromePath             The path to the Chrome or Chromium executable to use for
+                           collection.
+  --puppeteerScript        The path to a script that manipulates the browser with
+                           puppeteer before running Lighthouse, used for auth.
+  --puppeteerLaunchOptions The path to a script that manipulates the browser with
+                           puppeteer before running Lighthouse, used for auth.
+  --startServerCommand     The command to run to start the server.
+  --settings               The Lighthouse settings and flags to use when collecting
+  --numberOfRuns, -n       The number of times to run Lighthouse.
                                                            [number] [default: 3]
 ```
 
@@ -143,6 +145,8 @@ lhci collect --start-server-command="yarn serve" --url=http://localhost:8080/ --
 
 #### Using Puppeteer Scripts
 
+**NOTE:** In order to use puppeteer scripts, you need to install `puppeteer` yourself, i.e. `npm install --save puppeteer`. Any version you like that has a `.launch` method compatible with v1.x or v2.x and works with the Chrome version installed in your environment should work.
+
 When running Lighthouse CI on a page with behind authentication, you'll need to authorize the browser that Lighthouse CI will be using. While there are [several](./configuration.md#page-behind-authentication) different [options](https://github.com/GoogleChrome/lighthouse/blob/v5.6.0/docs/authenticated-pages.md) to accomplish this, `--puppeteer-script` is one of the most flexible and convenient.
 
 `--puppeteer-script` accepts a path to a JavaScript file that exports a function that will be invoked by Lighthouse CI before navigating, e.g. a script that will login to your site.
@@ -164,7 +168,7 @@ module.exports = async (browser, context) => {
 };
 ```
 
-Lighthouse CI will then use this browser that the script sets up when running Lighthouse. Note that if you store your credentials in `localStorage` or anything other than a cookie you might want to pair this option with `--settings.disableStorageReset` to force Lighthouse to keep the cache state.
+Lighthouse CI will then use the browser that this script sets up when running Lighthouse. Note that if you store your credentials in `localStorage` or anything other than a cookie you might want to pair this option with `--settings.disableStorageReset` to force Lighthouse to keep the cache state.
 
 For more information on how to use puppeteer, read up on [their API docs](https://github.com/puppeteer/puppeteer/blob/v2.0.0/docs/api.md#class-browser).
 

--- a/packages/cli/src/collect/collect.js
+++ b/packages/cli/src/collect/collect.js
@@ -39,6 +39,9 @@ function buildCommand(yargs) {
       description:
         'The path to a script that manipulates the browser with puppeteer before running Lighthouse, used for auth.',
     },
+    puppeteerLaunchOptions: {
+      description: 'The object of puppeteer launch options',
+    },
     startServerCommand: {
       description: 'The command to run to start the server.',
     },

--- a/packages/cli/src/collect/puppeteer-manager.js
+++ b/packages/cli/src/collect/puppeteer-manager.js
@@ -26,7 +26,9 @@ class PuppeteerManager {
     // Delay require to only run after user requests puppeteer functionality.
     const puppeteer = require('puppeteer');
     this._browser = await puppeteer.launch({
+      ...(this._options.puppeteerLaunchOptions || {}),
       pipe: false,
+      devtools: false,
       headless: !this._options.headful,
       executablePath: this._options.chromePath,
     });

--- a/packages/cli/test/collect-puppeteer.test.js
+++ b/packages/cli/test/collect-puppeteer.test.js
@@ -22,12 +22,16 @@ describe('Lighthouse CI collect CLI with puppeteer', () => {
         '-n=1',
         '--url=http://localhost:52426',
         '--start-server-command=node ./auth-server.js',
+        '--settings.emulatedFormFactor=none',
         '--puppeteer-script=./auth-server-script.js',
+        '--puppeteer-launch-options.args=--no-sandbox',
+        '--puppeteer-launch-options.args=--user-agent=lighthouseci',
       ],
       {cwd: autorunDir}
     );
 
     // The server above will return a 401 Unauthorized when the login script isn't invoked.
+    // The server above will return a 500 Server Error when the user agent isn't passed.
     // 4xx and 5xx status codes cause Lighthouse to exit with 1 and collect to fail.
     // Just succeeding here is enough to signal that our login script worked.
     expect(stdout).toMatchInlineSnapshot(`

--- a/packages/cli/test/fixtures/puppeteer/auth-server.js
+++ b/packages/cli/test/fixtures/puppeteer/auth-server.js
@@ -5,6 +5,7 @@
  */
 'use strict';
 
+const fs = require('fs');
 const express = require('express');
 const app = express();
 app.get('/', (req, res) => {
@@ -12,6 +13,14 @@ app.get('/', (req, res) => {
   if (!cookies.includes('loggedin=')) {
     res.status(401);
     res.send(`<!DOCTYPE html><html>Unauthorized`);
+    return;
+  }
+
+  const userAgent = req.header('user-agent') || '';
+  if (!userAgent.includes('lighthouseci')) {
+    fs.writeFileSync('ua.tmp.json', JSON.stringify({userAgent}));
+    res.status(500);
+    res.send(`<!DOCTYPE html><html>Invalid UA`);
     return;
   }
 

--- a/types/collect.d.ts
+++ b/types/collect.d.ts
@@ -44,6 +44,8 @@ declare global {
         startServerCommand?: string;
         chromePath?: string;
         puppeteerScript?: string;
+        /** @see https://github.com/puppeteer/puppeteer/blob/v2.0.0/docs/api.md#puppeteerlaunchoptions */
+        puppeteerLaunchOptions?: import('puppeteer').LaunchOptions;
         method: 'node';
         numberOfRuns: number;
         headful: boolean;


### PR DESCRIPTION
example usage:

```json5
{
  "ci": {
    "collect": {
      "puppteerLaunchOptions": {"args": ["--no-sandbox", "--disable-gpu"]}
    }
  }
}
```

closes #132
closes #133