### PR TITLE
feat(collect): support custom listening pattern for startServerCommand

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -110,25 +110,27 @@ lhci collect --help
 Run Lighthouse and save the results to a local folder
 
 Options:
-  --help                   Show help                                      [boolean]
-  --version                Show version number                            [boolean]
-  --config                 Path to JSON config file
-  --method                             [string] [choices: "node"] [default: "node"]
-  --headful                Run with a headful Chrome                      [boolean]
-  --additive               Skips clearing of previous collect data        [boolean]
-  --url                    A URL to run Lighthouse on.  You can evaluate multiple
-                           URLs by adding this flag multiple times.
-  --staticDistDir          The build directory where your HTML files to run
-                           Lighthouse on are located.
-  --chromePath             The path to the Chrome or Chromium executable to use for
-                           collection.
-  --puppeteerScript        The path to a script that manipulates the browser with
-                           puppeteer before running Lighthouse, used for auth.
-  --puppeteerLaunchOptions The path to a script that manipulates the browser with
-                           puppeteer before running Lighthouse, used for auth.
-  --startServerCommand     The command to run to start the server.
-  --settings               The Lighthouse settings and flags to use when collecting
-  --numberOfRuns, -n       The number of times to run Lighthouse.
+  --help                    Show help                                      [boolean]
+  --version                 Show version number                            [boolean]
+  --config                  Path to JSON config file
+  --method                              [string] [choices: "node"] [default: "node"]
+  --headful                 Run with a headful Chrome                      [boolean]
+  --additive                Skips clearing of previous collect data        [boolean]
+  --url                     A URL to run Lighthouse on.  You can evaluate multiple
+                            URLs by adding this flag multiple times.
+  --staticDistDir           The build directory where your HTML files to run
+                            Lighthouse on are located.
+  --chromePath              The path to the Chrome or Chromium executable to use for
+                            collection.
+  --puppeteerScript         The path to a script that manipulates the browser with
+                            puppeteer before running Lighthouse, used for auth.
+  --puppeteerLaunchOptions  The path to a script that manipulates the browser with
+                            puppeteer before running Lighthouse, used for auth.
+  --startServerCommand      The command to run to start the server.
+  --startServerReadyPattern String pattern to listen for started server.
+                                              [string] [default: "listen|ready"]
+  --settings                The Lighthouse settings and flags to use when collecting
+  --numberOfRuns, -n        The number of times to run Lighthouse.
                                                            [number] [default: 3]
 ```
 

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -9,8 +9,8 @@
 
 jest.retryTimes(3);
 
-const os = require('os');
 const path = require('path');
+const os = require('os');
 const {spawn} = require('child_process');
 const fetch = require('isomorphic-fetch');
 const log = require('lighthouse-logger');
@@ -29,7 +29,6 @@ describe('Lighthouse CI CLI', () => {
   const rcMatrixFile = path.join(__dirname, 'fixtures/lighthouserc-matrix.json');
   const rcExtendedFile = path.join(__dirname, 'fixtures/lighthouserc-extended.json');
   const budgetsFile = path.join(__dirname, 'fixtures/budgets.json');
-  const staticDistDir = path.join(__dirname, 'fixtures');
   const tmpSqlFilePath = getSqlFilePath();
 
   let server;
@@ -148,30 +147,8 @@ describe('Lighthouse CI CLI', () => {
     });
   });
 
+  // FIXME: Tests dependency. Moving these tests breaks others.
   describe('collect', () => {
-    it('should collect results from staticDistDir', () => {
-      const {stdout, stderr, status} = runCLI([
-        'collect',
-        `--config=${rcFile}`,
-        `--static-dist-dir=${staticDistDir}`,
-      ]);
-
-      const stdoutClean = stdout;
-      expect(stdoutClean).toMatchInlineSnapshot(`
-        "Started a web server on port XXXX...
-        Running Lighthouse 2 time(s) on http://localhost:XXXX/checkout.html
-        Run #1...done.
-        Run #2...done.
-        Running Lighthouse 2 time(s) on http://localhost:XXXX/index.html
-        Run #1...done.
-        Run #2...done.
-        Done running Lighthouse!
-        "
-      `);
-      expect(stderr.toString()).toMatchInlineSnapshot(`""`);
-      expect(status).toEqual(0);
-    }, 90000);
-
     it('should collect results with a server command', () => {
       // FIXME: for some inexplicable reason this test cannot pass in Travis Windows
       if (os.platform() === 'win32') return;
@@ -196,7 +173,6 @@ describe('Lighthouse CI CLI', () => {
       expect(stderr.toString()).toMatchInlineSnapshot(`""`);
       expect(status).toEqual(0);
     }, 60000);
-
     it('should collect results from explicit urls', () => {
       const {stdout, stderr, status} = runCLI([
         'collect',

--- a/packages/cli/test/collect.test.js
+++ b/packages/cli/test/collect.test.js
@@ -1,0 +1,120 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+const os = require('os');
+const path = require('path');
+const {runCLI, withTmpDir, cleanStdOutput} = require('./test-utils.js');
+
+describe('collect', () => {
+  const fixturesDir = path.join(__dirname, 'fixtures');
+  const rcFile = path.join(fixturesDir, 'lighthouserc.json');
+
+  it(
+    'should collect results from staticDistDir',
+    () =>
+      withTmpDir(tmpDir => {
+        const {stdout, stderr, status} = runCLI(
+          ['collect', `--config=${rcFile}`, `--static-dist-dir=${fixturesDir}`],
+          {
+            // Run in temp dir to avoid conflicts with other tests
+            cwd: tmpDir,
+          }
+        );
+
+        const stdoutClean = stdout;
+        expect(stdoutClean).toMatchInlineSnapshot(`
+          "Started a web server on port XXXX...
+          Running Lighthouse 2 time(s) on http://localhost:XXXX/checkout.html
+          Run #1...done.
+          Run #2...done.
+          Running Lighthouse 2 time(s) on http://localhost:XXXX/index.html
+          Run #1...done.
+          Run #2...done.
+          Done running Lighthouse!
+          "
+        `);
+        expect(stderr.toString()).toMatchInlineSnapshot(`""`);
+        expect(status).toEqual(0);
+      }),
+    90000
+  );
+
+  it('should collect results with a server command with custom start pattern', () =>
+    withTmpDir(tmpDir => {
+      // FIXME: for some inexplicable reason this test cannot pass in Travis Windows
+      if (os.platform() === 'win32') return;
+
+      const serverPath = path.join(fixturesDir, 'autorun-start-server/autorun-server.js');
+      const startCommand = `SERVER_START_PORT=52427 SERVER_START_MESSAGE='Running server' node ${serverPath}`;
+      const {stdout, stderr, status} = runCLI(
+        [
+          'collect',
+          `-n=1`,
+          `--config=${rcFile}`,
+          `--start-server-command=${startCommand}`,
+          '--start-server-ready-pattern=running',
+          '--url=http://localhost:52427/',
+        ],
+        {
+          // Run in temp dir to avoid conflicts with other tests
+          cwd: tmpDir,
+        }
+      );
+
+      // Check server started and lighthouse ran.
+      const cleanStartCommand = cleanStdOutput(startCommand);
+      expect(stdout).toMatchInlineSnapshot(`
+        "Started a web server with \\"${cleanStartCommand}\\"...
+        Running Lighthouse 1 time(s) on http://localhost:XXXX/
+        Run #1...done.
+        Done running Lighthouse!
+        "
+      `);
+      // Checkout no errors were logged.
+      expect(stderr.toString()).toMatchInlineSnapshot(`""`);
+      // Check script ran without errors.
+      expect(status).toEqual(0);
+    }));
+
+  it('should print timeout message for server command not printing a matchable pattern', () =>
+    withTmpDir(tmpDir => {
+      // FIXME: for some inexplicable reason this test cannot pass in Travis Windows
+      if (os.platform() === 'win32') return;
+
+      const serverPath = path.join(fixturesDir, 'autorun-start-server/autorun-server.js');
+      const startCommand = `SERVER_START_PORT=52428 SERVER_START_MESSAGE='Running server' node ${serverPath}`;
+      const {stdout, status} = runCLI(
+        [
+          'collect',
+          `-n=1`,
+          `--config=${rcFile}`,
+          `--start-server-command=${startCommand}`,
+          '--url=http://localhost:52428/',
+        ],
+        {
+          // Run in temp dir to avoid conflicts with other tests
+          cwd: tmpDir,
+        }
+      );
+
+      // Check server started and lighthouse ran.
+      const cleanStartCommand = cleanStdOutput(startCommand);
+      expect(stdout).toMatchInlineSnapshot(`
+        "Started a web server with \\"${cleanStartCommand}\\"...
+        WARNING: Timed out waiting for the server to start listening.
+                 Ensure the server prints a matching pattern /listen|ready/i when it is ready.
+        Running Lighthouse 1 time(s) on http://localhost:XXXX/
+        Run #1...done.
+        Done running Lighthouse!
+        "
+      `);
+      // Check script ran without errors.
+      expect(status).toEqual(0);
+    }));
+});

--- a/packages/cli/test/fixtures/autorun-start-server/autorun-server.js
+++ b/packages/cli/test/fixtures/autorun-start-server/autorun-server.js
@@ -22,4 +22,9 @@ app.get('/', (_, res) => {
   `);
 });
 
-app.listen(52425, () => process.stdout.write('Listening...'));
+const {
+  SERVER_START_MESSAGE = 'Server listening on port...',
+  SERVER_START_PORT = 52425,
+} = process.env;
+
+app.listen(SERVER_START_PORT, () => process.stdout.write(SERVER_START_MESSAGE));

--- a/packages/cli/test/test-utils.js
+++ b/packages/cli/test/test-utils.js
@@ -115,4 +115,5 @@ module.exports = {
   getSqlFilePath,
   safeDeleteFile,
   withTmpDir,
+  cleanStdOutput,
 };

--- a/types/collect.d.ts
+++ b/types/collect.d.ts
@@ -42,6 +42,7 @@ declare global {
         url?: string | string[];
         staticDistDir?: string;
         startServerCommand?: string;
+        startServerReadyPattern: string;
         chromePath?: string;
         puppeteerScript?: string;
         /** @see https://github.com/puppeteer/puppeteer/blob/v2.0.0/docs/api.md#puppeteerlaunchoptions */


### PR DESCRIPTION
This PR introduces the changes to support custom listening pattern for `startServerCommand` through the new collect option `startServerReadyPattern`.

Closes https://github.com/GoogleChrome/lighthouse-ci/issues/134