### PR TITLE
Allow use of merge commits in build hash; add Gitlab CI variable to get hash

### DIFF
--- a/packages/utils/src/build-context.js
+++ b/packages/utils/src/build-context.js
@@ -67,7 +67,7 @@ function getCurrentHash() {
   ]);
   if (envHash) return envHash;
 
-  const result = childProcess.spawnSync('git', ['rev-parse', 'HEAD'], {
+  const result = childProcess.spawnSync('git', ['rev-list', '--no-merges', '-n1', 'HEAD'], {
     encoding: 'utf8',
   });
   if (result.status !== 0) {

--- a/packages/utils/src/build-context.js
+++ b/packages/utils/src/build-context.js
@@ -67,7 +67,7 @@ function getCurrentHash() {
   ]);
   if (envHash) return envHash;
 
-  const result = childProcess.spawnSync('git', ['rev-list', '--no-merges', '-n1', 'HEAD'], {
+  const result = childProcess.spawnSync('git', ['rev-parse', 'HEAD'], {
     encoding: 'utf8',
   });
   if (result.status !== 0) {

--- a/packages/utils/src/build-context.js
+++ b/packages/utils/src/build-context.js
@@ -62,6 +62,8 @@ function getCurrentHash() {
     'TRAVIS_COMMIT',
     // Circle CI
     'CIRCLE_SHA1',
+    // GitLab CI
+    'CI_COMMIT_SHA',
   ]);
   if (envHash) return envHash;
 


### PR DESCRIPTION
I noticed lhci uses the last commit _that is not a merge commit_ when I ran in Gitlab CI. I think this behaviour is not desired because most CI providers set variables like `CIRCLE_SHA1` to the actual commit (even if it is a merge commit), so this creates inconsistencies between CI providers. This PR fixes two things:

- Read `CI_COMMIT_SHA` env variable to get the commit hash from Gitlab CI.
- When falling back to getting the hash form `git`, do not exclude merge commit so the hash is equal to that of any env variables. I also think this is better because people can still break something when resolving merge conflicts.