### PR TITLE
NEW add configuration argument to wizard command

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -291,7 +291,7 @@ module.exports = {
 
 ### Custom headers for running the wizard
 
-If you're running the `lhci server` behind an reverse proxy or any other component that requires some `extra headers` you can configure them in the wizard section `extraHeaders`.
+If you're running the `lhci server` behind a reverse proxy or any other component that requires some extra headers you can configure them in the wizard section `extraHeaders`.
 
 ```json
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -308,7 +308,7 @@ If you're running the `lhci server` behind an reverse proxy or any other compone
 
 ### Default lhci server location for running the wizard
 
-If you're running the `lhci wizard` multiple times, you can configure a default `serverBaseUrl` that you have to type them in at each `lhci wizard` run.
+If you're running the `lhci wizard` multiple times, you can configure a default `serverBaseUrl` to avoid typing it in at each `lhci wizard` run.
 
 ```json
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,9 @@ module.exports = {
     server: {
       // server options here
     },
+    wizard: {
+      // wizard options here
+    }
   },
 };
 ```
@@ -78,6 +81,9 @@ module.exports = {
     },
     "server": {
       // server options here
+    },
+    "wizard": {
+      // wizard options here
     }
   }
 }
@@ -98,6 +104,9 @@ ci:
 
   server:
     # server options here
+  
+  wizard:
+    # wizard options here
 ```
 
 ## Recommendations
@@ -279,6 +288,39 @@ module.exports = {
   },
 };
 ```
+
+### Custom headers for running the wizard
+
+If you're running the `lhci server` behind an reverse proxy or any other component that requires some `extra headers` you can configure them in the wizard section `extraHeaders`.
+
+```json
+{
+  "ci": {
+    "wizzard": {
+      "extraHeaders": "{\"Authorization\": \"Basic content\"}"
+    }
+  }
+}
+```
+
+> **_NOTE:_** The `wizard` options will be overriten by the `upload` options, to be sure that the wizard options will be used, create a seperate config file
+
+
+### Default lhci server location for running the wizard
+
+If you're running the `lhci wizard` multiple times, you can configure a default `serverBaseUrl` that you have to type them in at each `lhci wizard` run.
+
+```json
+{
+  "ci": {
+    "wizzard": {
+      "serverBaseUrl": "https://localhost:3000/",
+    }
+  }
+}
+```
+
+> **_NOTE:_** The `wizard` options will be overriten by the `upload` options, to be sure that the wizard options will be used, create a seperate config file
 
 ### YAML Advanced config
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -303,7 +303,7 @@ If you're running the `lhci server` behind a reverse proxy or any other componen
 }
 ```
 
-> **_NOTE:_** The `wizard` options will be overriten by the `upload` options, to be sure that the wizard options will be used, create a seperate config file
+> **_NOTE:_** The `wizard` options will be overwritten by the `upload` options, to be sure that the wizard options will be used, create a separate config file.
 
 
 ### Default lhci server location for running the wizard

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -320,7 +320,7 @@ If you're running the `lhci wizard` multiple times, you can configure a default 
 }
 ```
 
-> **_NOTE:_** The `wizard` options will be overriten by the `upload` options, to be sure that the wizard options will be used, create a seperate config file
+> **_NOTE:_** The `wizard` options will be overwritten by the `upload` options, to be sure that the wizard options will be used, create a separate config file.
 
 ### YAML Advanced config
 

--- a/packages/cli/src/wizard/wizard.js
+++ b/packages/cli/src/wizard/wizard.js
@@ -50,7 +50,10 @@ async function runNewProjectWizard(options) {
     },
   ]);
 
-  const api = new ApiClient({rootURL: responses.serverBaseUrl || options.serverBaseUrl, extraHeaders: options.extraHeaders || {}});
+  const api = new ApiClient({
+    rootURL: responses.serverBaseUrl || options.serverBaseUrl,
+    extraHeaders: options.extraHeaders || {},
+  });
   const project = await api.createProject({
     name: responses.projectName,
     externalUrl: responses.projectExternalUrl,
@@ -72,9 +75,9 @@ async function runCommand(options) {
   const wizardConfiguration = rcFile ? flattenRcToConfig(rcFile) : {};
   options = {
     ...options,
-    ...wizardConfiguration.wizard
-  }
-  
+    ...wizardConfiguration.wizard,
+  };
+
   const whichWizardPrompt = await inquirer.prompt([
     {
       type: 'list',

--- a/packages/cli/src/wizard/wizard.js
+++ b/packages/cli/src/wizard/wizard.js
@@ -7,11 +7,6 @@
 
 const inquirer = require('inquirer');
 const ApiClient = require('@lhci/utils/src/api-client.js');
-const {
-  loadRcFile,
-  flattenRcToConfig,
-  resolveRcFilePath,
-} = require('@lhci/utils/src/lighthouserc.js');
 const _ = require('@lhci/utils/src/lodash.js');
 const log = require('lighthouse-logger');
 
@@ -19,9 +14,7 @@ const log = require('lighthouse-logger');
  * @param {import('yargs').Argv} yargs
  */
 function buildCommand(yargs) {
-  return yargs.options({
-    config: {description: 'The lighthouserc.json file preferences.'},
-  });
+  return yargs;
 }
 
 /**
@@ -70,14 +63,6 @@ async function runNewProjectWizard(options) {
  * @return {Promise<void>}
  */
 async function runCommand(options) {
-  const rcFilePath = resolveRcFilePath(options.config);
-  const rcFile = rcFilePath && loadRcFile(rcFilePath);
-  const wizardConfiguration = rcFile ? flattenRcToConfig(rcFile) : {};
-  options = {
-    ...options,
-    ...wizardConfiguration.wizard,
-  };
-
   const whichWizardPrompt = await inquirer.prompt([
     {
       type: 'list',

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -100,7 +100,12 @@ describe('Lighthouse CI CLI', () => {
     }, 30000);
 
     it('should create a new project with config file', async () => {
-      const wizardProcess = spawn('node', [CLI_PATH, 'wizard', `--config=${rcFile}`]);
+      const wizardTempConfigFile = { "ci": {"wizard": {"serverBaseUrl": `http://localhost:${server.port}`}}};
+      const tmpFolder = fs.mkdtempSync(`${os.tmpdir()}${path.sep}`);
+      const wizardRcFile = `${tmpFolder}/wizard.json`
+      fs.writeFileSync(wizardRcFile, JSON.stringify(wizardTempConfigFile), {encoding: 'utf8'});
+      
+      const wizardProcess = spawn('node', [CLI_PATH, 'wizard', `--config=${wizardRcFile}`]);
       wizardProcess.stdoutMemory = '';
       wizardProcess.stderrMemory = '';
       wizardProcess.stdout.on(
@@ -117,8 +122,8 @@ describe('Lighthouse CI CLI', () => {
         'https://example.com', // External build URL
       ]);
 
-      expect(wizardProcess.stdoutMemory).toContain('https://github.com/GoogleChrome/lighthouse-ci');
-      // expect(wizardProcess.stderrMemory).toEqual(''); // Ignore error - test focused on reading config file only
+      expect(wizardProcess.stdoutMemory).toContain(`http://localhost:${server.port}`);
+      expect(wizardProcess.stderrMemory).toEqual('');
     }, 30000);
   });
 

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -103,27 +103,19 @@ describe('Lighthouse CI CLI', () => {
       const wizardProcess = spawn('node', [CLI_PATH, 'wizard', `--config=${rcFile}`]);
       wizardProcess.stdoutMemory = '';
       wizardProcess.stderrMemory = '';
-      wizardProcess.stdout.on('data', chunk => (wizardProcess.stdoutMemory += chunk.toString()));
+      wizardProcess.stdout.on('data', chunk => (wizardProcess.stdoutMemory += chunk.toString().replace(/\n/g,'')));
       wizardProcess.stderr.on('data', chunk => (wizardProcess.stderrMemory += chunk.toString()));
 
       await waitForCondition(() => wizardProcess.stdoutMemory.includes('Which wizard'));
       await writeAllInputs(wizardProcess, [
         '', // Just ENTER key to select "new-project"
-        `http://localhost:${server.port}`, // The base URL to talk to
+        '', // Just ENTER key to use serverBaseUrl from config file
         'AwesomeCIProjectName', // Project name
         'https://example.com', // External build URL
       ]);
-
-      expect(wizardProcess.stdoutMemory).toContain('Use token');
-      expect(wizardProcess.stderrMemory).toEqual('');
-      const tokenSentence = wizardProcess.stdoutMemory
-        .match(/Use token [\s\S]+/im)[0]
-        .replace(log.bold, '')
-        .replace(log.reset, '');
-      projectToken = tokenSentence.match(/Use token ([\w-]+)/)[1];
       
-      expect(wizardProcess.stdoutMemory).toContain('\"serverBaseUrl\":\"https://github.com/GoogleChrome/lighthouse-ci\"')
-      expect(wizardProcess.stdoutMemory).toContain('\"extraHeaders\":\" {\\\"Authorization\\\": \\\"Basic bGlnaHRob3VzZTpjaQo=\\\"}\"}')
+      expect(wizardProcess.stdoutMemory).toContain('https://github.com/GoogleChrome/lighthouse-ci');
+      expect(wizardProcess.stderrMemory).toEqual('');
 
     }, 30000);
   });

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -100,11 +100,13 @@ describe('Lighthouse CI CLI', () => {
     }, 30000);
 
     it('should create a new project with config file', async () => {
-      const wizardTempConfigFile = { "ci": {"wizard": {"serverBaseUrl": `http://localhost:${server.port}`}}};
+      const wizardTempConfigFile = {
+        ci: {wizard: {serverBaseUrl: `http://localhost:${server.port}`}},
+      };
       const tmpFolder = fs.mkdtempSync(`${os.tmpdir()}${path.sep}`);
-      const wizardRcFile = `${tmpFolder}/wizard.json`
+      const wizardRcFile = `${tmpFolder}/wizard.json`;
       fs.writeFileSync(wizardRcFile, JSON.stringify(wizardTempConfigFile), {encoding: 'utf8'});
-      
+
       const wizardProcess = spawn('node', [CLI_PATH, 'wizard', `--config=${wizardRcFile}`]);
       wizardProcess.stdoutMemory = '';
       wizardProcess.stderrMemory = '';

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -103,7 +103,10 @@ describe('Lighthouse CI CLI', () => {
       const wizardProcess = spawn('node', [CLI_PATH, 'wizard', `--config=${rcFile}`]);
       wizardProcess.stdoutMemory = '';
       wizardProcess.stderrMemory = '';
-      wizardProcess.stdout.on('data', chunk => (wizardProcess.stdoutMemory += chunk.toString().replace(/\n/g,'')));
+      wizardProcess.stdout.on(
+        'data',
+        chunk => (wizardProcess.stdoutMemory += chunk.toString().replace(/\n/g, ''))
+      );
       wizardProcess.stderr.on('data', chunk => (wizardProcess.stderrMemory += chunk.toString()));
 
       await waitForCondition(() => wizardProcess.stdoutMemory.includes('Which wizard'));
@@ -113,10 +116,9 @@ describe('Lighthouse CI CLI', () => {
         'AwesomeCIProjectName', // Project name
         'https://example.com', // External build URL
       ]);
-      
-      expect(wizardProcess.stdoutMemory).toContain('https://github.com/GoogleChrome/lighthouse-ci');
-      expect(wizardProcess.stderrMemory).toEqual('');
 
+      expect(wizardProcess.stdoutMemory).toContain('https://github.com/GoogleChrome/lighthouse-ci');
+      // expect(wizardProcess.stderrMemory).toEqual(''); // Ignore error - test focused on reading config file only
     }, 30000);
   });
 

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -237,7 +237,7 @@ describe('Lighthouse CI CLI', () => {
         Saved LHR to http://localhost:XXXX (<UUID>)
         Saved LHR to http://localhost:XXXX (<UUID>)
         Done saving build results to Lighthouse CI
-        View build diff at http://localhost:XXXX/app/projects/awesomeciprojectname-s/compare/<UUID>
+        View build diff at http://localhost:XXXX/app/projects/awesomeciprojectname/compare/<UUID>
         No GitHub token set, skipping.
         "
       `);
@@ -251,7 +251,7 @@ describe('Lighthouse CI CLI', () => {
       const links = fs.readFileSync(linksFile, 'utf8');
       expect(cleanStdOutput(links)).toMatchInlineSnapshot(`
         "{
-          \\"http://localhost:XXXX/app/\\": \\"http://localhost:XXXX/app/projects/awesomeciprojectname-s/compare/<UUID>?compareUrl=http%3A%2F%2Flocalhost%3APORT%2Fapp%2F\\"
+          \\"http://localhost:XXXX/app/\\": \\"http://localhost:XXXX/app/projects/awesomeciprojectname/compare/<UUID>?compareUrl=http%3A%2F%2Flocalhost%3APORT%2Fapp%2F\\"
         }"
       `);
     });

--- a/packages/cli/test/fixtures/lighthouserc.json
+++ b/packages/cli/test/fixtures/lighthouserc.json
@@ -22,10 +22,6 @@
       "storage": {
         "sqlDatabasePath": "cli-test-fixtures.tmp.sql"
       }
-    },
-    "wizard": {
-      "serverBaseUrl": "https://github.com/GoogleChrome/lighthouse-ci",
-      "extraHeaders":" {\"Authorization\": \"Basic bGlnaHRob3VzZTpjaQo=\"}"
     }
   }
 }

--- a/packages/cli/test/fixtures/lighthouserc.json
+++ b/packages/cli/test/fixtures/lighthouserc.json
@@ -22,6 +22,10 @@
       "storage": {
         "sqlDatabasePath": "cli-test-fixtures.tmp.sql"
       }
+    },
+    "wizard": {
+      "serverBaseUrl": "https://github.com/GoogleChrome/lighthouse-ci",
+      "extraHeaders":" {\"Authorization\": \"Basic bGlnaHRob3VzZTpjaQo=\"}"
     }
   }
 }

--- a/packages/utils/src/lighthouserc.js
+++ b/packages/utils/src/lighthouserc.js
@@ -135,7 +135,7 @@ function hasOptedOutOfRcDetection(argv = process.argv, env = process.env) {
 function convertRcFileToYargsOptions(rcFile, pathToRcFile) {
   const ci = flattenRcToConfig(rcFile);
   /** @type {LHCI.YargsOptions} */
-  let merged = {...ci.assert, ...ci.collect, ...ci.upload, ...ci.server};
+  let merged = {...ci.wizard, ...ci.assert, ...ci.collect, ...ci.upload, ...ci.server};
   if (ci.extends) {
     const extendedRcFilePath = path.resolve(path.dirname(pathToRcFile), ci.extends);
     const extensionBase = loadAndParseRcFile(extendedRcFilePath);

--- a/packages/utils/test/lighthouserc.test.js
+++ b/packages/utils/test/lighthouserc.test.js
@@ -154,6 +154,72 @@ describe('lighthouserc.js', () => {
         expect(rc.loadAndParseRcFile(rcYamlFilePath)).toEqual(parsedContent);
       });
     });
+
+    describe('should load overlapping upload and wizard configuration', () => {
+      const content = {
+        ci: {
+          upload: {
+            serverBaseUrl: 'http://localhost:9009',
+            extraHeaders: '{"Authorization": "Basic bGlnaHRob3VzZTpjaQo="}',
+          },
+          wizard: {
+            serverBaseUrl: 'https://localhost:9010',
+            extraHeaders: '{"Authorization": "Basic noContent"}',
+          },
+        },
+      };
+
+      const parsedContent = {
+        serverBaseUrl: 'http://localhost:9009',
+        extraHeaders: '{"Authorization": "Basic bGlnaHRob3VzZTpjaQo="}',
+      };
+
+      it('Js', () => {
+        writeJsFile(rcJsFilePath, content);
+        expect(rc.loadAndParseRcFile(rcJsFilePath)).toEqual(parsedContent);
+      });
+
+      it('JSON', () => {
+        writeJSONFile(rcJSONFilePath, content);
+        expect(rc.loadAndParseRcFile(rcJSONFilePath)).toEqual(parsedContent);
+      });
+
+      it('YAML', () => {
+        writeYAMLFile(rcYamlFilePath, content);
+        expect(rc.loadAndParseRcFile(rcYamlFilePath)).toEqual(parsedContent);
+      });
+    });
+
+    describe('should load wizard configuration', () => {
+      const content = {
+        ci: {
+          wizard: {
+            serverBaseUrl: 'http://localhost:9009',
+            extraHeaders: '{"Authorization": "Basic bGlnaHRob3VzZTpjaQo="}',
+          },
+        },
+      };
+
+      const parsedContent = {
+        serverBaseUrl: 'http://localhost:9009',
+        extraHeaders: '{"Authorization": "Basic bGlnaHRob3VzZTpjaQo="}',
+      };
+
+      it('Js', () => {
+        writeJsFile(rcJsFilePath, content);
+        expect(rc.loadAndParseRcFile(rcJsFilePath)).toEqual(parsedContent);
+      });
+
+      it('JSON', () => {
+        writeJSONFile(rcJSONFilePath, content);
+        expect(rc.loadAndParseRcFile(rcJSONFilePath)).toEqual(parsedContent);
+      });
+
+      it('YAML', () => {
+        writeYAMLFile(rcYamlFilePath, content);
+        expect(rc.loadAndParseRcFile(rcYamlFilePath)).toEqual(parsedContent);
+      });
+    });
   });
 
   describe('#findRcFile', () => {

--- a/types/lighthouserc.d.ts
+++ b/types/lighthouserc.d.ts
@@ -12,6 +12,7 @@ declare global {
       collect?: Partial<CollectCommand.Options>;
       upload?: Partial<UploadCommand.Options>;
       server?: Partial<ServerCommand.Options>;
+      wizard?: Partial<WizardCommand.Options>;
     }
 
     export interface LighthouseRc {

--- a/types/wizard.d.ts
+++ b/types/wizard.d.ts
@@ -8,6 +8,8 @@ declare global {
   namespace LHCI {
     namespace WizardCommand {
       export interface Options {
+        config?: string;
+        extraHeaders?: Record<string, string>;
         serverBaseUrl?: string;
       }
     }

--- a/types/wizard.d.ts
+++ b/types/wizard.d.ts
@@ -8,7 +8,6 @@ declare global {
   namespace LHCI {
     namespace WizardCommand {
       export interface Options {
-        config?: string;
         extraHeaders?: Record<string, string>;
         serverBaseUrl?: string;
       }


### PR DESCRIPTION
Hi,

i created the pr because we're running the `lhci server` behind a reverse proxy with authentication.
Now it's not possible to the the `lhci wizard` on a local machine because the wizard can't reach the server (missing authentication headers).

To fix that issue I changed the wizard command that a user can pass the `--config` argument (like autorun)

Example: 
`lhci wizard --config=./lighthouserc.json`

In the passed configuration it was now possible to set two different things:
- extraHeaders
- serverBaseUrl

The extraHeaders will be uses when the `lhci server` will be called.  
The serverBaseUrl can be used to set a default location for the remote `lhci server` address. 

Example configuration file: 
```javascript
{
  "ci": {
  "wizard": {
      "serverBaseUrl": "https://github.com/GoogleChrome/lighthouse-ci",
      "extraHeaders":" {\"Authorization\": \"Basic <BASE64>"}"
    }
  }
}
```

Hope you like the implementation. 
I think to pass a configuration is better than changing the wizard for the user because passing an argument was a known concept in using `lhci`

Kind regards
Tobi 