### PR TITLE
Fix link to lighthouserc on troubleshooting doc to point to master

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,7 +52,7 @@ This is a precautionary measure to prevent the effective deletion of historical 
 
 If the URLs that you audit contain random components (ports, UUIDs, hashes, etc), then you'll need to tell LHCI how to normalize your data when you upload it with the `--url-replacement-patterns` option.
 
-When using this option, you'll lose the default `:PORT` and `UUID` replacements, so be sure to copy those into your configuration if necessary. [See the example in the lighthuose-ci repo itself](https://github.com/GoogleChrome/lighthouse-ci/blob/master/lighthouserc.json) for how to configure these patterns.
+When using this option, you'll lose the default `:PORT` and `UUID` replacements, so be sure to copy those into your configuration if necessary. [See the example in the lighthuose-ci repo itself](https://github.com/GoogleChrome/lighthouse-ci/blob/5485be50406f7b600b679bd447b493b6544b2682/lighthouserc.json#L32-L36) for how to configure these patterns.
 
 ## I'm seeing differences in the results even though I didn't change anything.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,7 +52,7 @@ This is a precautionary measure to prevent the effective deletion of historical 
 
 If the URLs that you audit contain random components (ports, UUIDs, hashes, etc), then you'll need to tell LHCI how to normalize your data when you upload it with the `--url-replacement-patterns` option.
 
-When using this option, you'll lose the default `:PORT` and `UUID` replacements, so be sure to copy those into your configuration if necessary. [See the example in the lighthuose-ci repo itself](https://github.com/GoogleChrome/lighthouse-ci/blob/v0.3.0-alpha.0/lighthouserc.json) for how to configure these patterns.
+When using this option, you'll lose the default `:PORT` and `UUID` replacements, so be sure to copy those into your configuration if necessary. [See the example in the lighthuose-ci repo itself](https://github.com/GoogleChrome/lighthouse-ci/blob/master/lighthouserc.json) for how to configure these patterns.
 
 ## I'm seeing differences in the results even though I didn't change anything.
 


### PR DESCRIPTION
Right now the current link takes to `v0.3.0-alpha.0` link where the file actually does not contain the section mentioned on the docs. This PR points the link to `master` where the section is present.