### PR TITLE
fix(assetions): normalize number assertion

### DIFF
--- a/packages/utils/src/assertions.js
+++ b/packages/utils/src/assertions.js
@@ -62,7 +62,7 @@ const isFiniteNumber = x => typeof x === 'number' && Number.isFinite(x);
  */
 function normalizeAssertion(assertion) {
   if (!assertion) return ['off', {}];
-  if (typeof assertion === 'string') return [assertion, {}];
+  if (typeof assertion === 'string' || typeof assertion === 'number') return [assertion, {}];
   return assertion;
 }
 


### PR DESCRIPTION
When using a number as assertion in the lighthouse configuration, the `normalizeAssertion` function will return a faulty "normalized assertion".

Example of a JSON which would have failed before this PR:
```json 
{
  "ci": {
    "assert": {
      "assertions": {
        "total-byte-weight": "0.74",
      }
    }
  }
}
```

Note: Even though the assertion value is written as string, it will get resolved as a number. I do not know where this is coming from though (maybe `JSON.parse`?).