### PR TITLE
Add basic admin auth to server API

### DIFF
--- a/packages/cli/src/wizard/wizard.js
+++ b/packages/cli/src/wizard/wizard.js
@@ -54,8 +54,11 @@ async function runNewProjectWizard(options) {
   });
 
   const token = project.token;
+  const adminToken = project.adminToken;
+  const adminWarning = 'to manage data. KEEP THIS SECRET!';
   process.stdout.write(`Created project ${project.name} (${project.id})!\n`);
-  process.stdout.write(`Use token ${log.bold}${token}${log.reset} to connect.\n`);
+  process.stdout.write(`Use token ${log.bold}${token}${log.reset} to add data.\n`);
+  process.stdout.write(`Use admin token ${log.bold}${adminToken}${log.reset} ${adminWarning}\n`);
 }
 
 /**

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -35,6 +35,7 @@ describe('Lighthouse CI CLI', () => {
 
   let server;
   let projectToken;
+  let projectAdminToken;
   let urlToCollect;
 
   afterAll(async () => {
@@ -90,6 +91,7 @@ describe('Lighthouse CI CLI', () => {
         'https://example.com', // External build URL
       ]);
 
+      // Extract the regular token
       expect(wizardProcess.stdoutMemory).toContain('Use token');
       expect(wizardProcess.stderrMemory).toEqual('');
       const tokenSentence = wizardProcess.stdoutMemory
@@ -97,6 +99,15 @@ describe('Lighthouse CI CLI', () => {
         .replace(log.bold, '')
         .replace(log.reset, '');
       projectToken = tokenSentence.match(/Use token ([\w-]+)/)[1];
+
+      // Extract the admin token
+      expect(wizardProcess.stdoutMemory).toContain('Use admintoken');
+      expect(wizardProcess.stderrMemory).toEqual('');
+      const adminSentence = wizardProcess.stdoutMemory
+        .match(/Use admin token [\s\S]+/im)[0]
+        .replace(log.bold, '')
+        .replace(log.reset, '');
+      projectAdminToken = adminSentence.match(/Use admin token (\w+)/)[1];
     }, 30000);
 
     it('should create a new project with config file', async () => {

--- a/packages/cli/test/fixtures/lighthouserc.json
+++ b/packages/cli/test/fixtures/lighthouserc.json
@@ -20,6 +20,8 @@
     "server": {
       "port": 9009,
       "storage": {
+        "storageMethod": "sql",
+        "sqlDialect": "sqlite",
         "sqlDatabasePath": "cli-test-fixtures.tmp.sql"
       }
     }

--- a/packages/server/src/api/express-utils.js
+++ b/packages/server/src/api/express-utils.js
@@ -5,6 +5,8 @@
  */
 'use strict';
 
+const {hashAdminToken} = require('./storage/auth.js');
+
 class E404 extends Error {}
 class E422 extends Error {}
 
@@ -39,8 +41,9 @@ module.exports = {
           const project = await context.storageMethod.findProjectById(req.params.projectId);
           if (!project) throw new Error('Invalid token');
 
-          const adminToken = req.header('x-lhci-admin-token');
-          if (adminToken !== project.adminToken) throw new Error('Invalid token');
+          const adminToken = req.header('x-lhci-admin-token') || '';
+          const hashedAdminToken = hashAdminToken(adminToken, project.id);
+          if (hashedAdminToken !== project.adminToken) throw new Error('Invalid token');
 
           next();
         })

--- a/packages/server/src/api/routes/projects.js
+++ b/packages/server/src/api/routes/projects.js
@@ -65,6 +65,16 @@ function createRouter(context) {
     })
   );
 
+  // DELETE /projects/:id
+  router.delete(
+    '/:projectId',
+    validateAdminTokenMiddleware(context),
+    handleAsyncError(async (req, res) => {
+      await context.storageMethod.deleteProject(req.params.projectId);
+      res.sendStatus(204);
+    })
+  );
+
   // GET /projects/<id>/builds
   router.get(
     '/:projectId/builds',

--- a/packages/server/src/api/routes/projects.js
+++ b/packages/server/src/api/routes/projects.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const express = require('express');
-const {handleAsyncError} = require('../express-utils.js');
+const {handleAsyncError, validateAdminTokenMiddleware} = require('../express-utils.js');
 
 /**
  * @param {{storageMethod: LHCI.ServerCommand.StorageMethod}} context
@@ -103,6 +103,16 @@ function createRouter(context) {
       unsavedBuild.projectId = req.params.projectId;
       const build = await context.storageMethod.createBuild(unsavedBuild);
       res.json(build);
+    })
+  );
+
+  // DELETE /projects/<id>/builds/<id>
+  router.delete(
+    '/:projectId/builds/:buildId',
+    validateAdminTokenMiddleware(context),
+    handleAsyncError(async (req, res) => {
+      await context.storageMethod.deleteBuild(req.params.projectId, req.params.buildId);
+      res.sendStatus(204);
     })
   );
 

--- a/packages/server/src/api/routes/projects.js
+++ b/packages/server/src/api/routes/projects.js
@@ -20,7 +20,7 @@ function createRouter(context) {
     '/',
     handleAsyncError(async (_, res) => {
       const projects = await context.storageMethod.getProjects();
-      res.json(projects.map(project => ({...project, token: ''})));
+      res.json(projects.map(project => ({...project, token: '', adminToken: ''})));
     })
   );
 
@@ -51,7 +51,7 @@ function createRouter(context) {
     handleAsyncError(async (req, res) => {
       const project = await context.storageMethod.findProjectBySlug(req.params.projectSlug);
       if (!project) return res.sendStatus(404);
-      res.json({...project, token: ''});
+      res.json({...project, token: '', adminToken: ''});
     })
   );
 
@@ -61,7 +61,7 @@ function createRouter(context) {
     handleAsyncError(async (req, res) => {
       const project = await context.storageMethod.findProjectById(req.params.projectId);
       if (!project) return res.sendStatus(404);
-      res.json({...project, token: ''});
+      res.json({...project, token: '', adminToken: ''});
     })
   );
 

--- a/packages/server/src/api/routes/projects.js
+++ b/packages/server/src/api/routes/projects.js
@@ -41,7 +41,7 @@ function createRouter(context) {
       const token = req.body.token;
       const project = await context.storageMethod.findProjectByToken(token);
       if (!project) return res.sendStatus(404);
-      res.json(project);
+      res.json({...project, adminToken: ''});
     })
   );
 

--- a/packages/server/src/api/storage/auth.js
+++ b/packages/server/src/api/storage/auth.js
@@ -1,0 +1,28 @@
+/**
+ * @license Copyright 2020 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const crypto = require('crypto');
+
+module.exports = {
+  /** Generates a cryptographically psuedorandom alphanumeric string of length 40. @return {string} */
+  generateAdminToken() {
+    return crypto
+      .randomBytes(30)
+      .toString('base64')
+      .replace(/[^a-z0-9]/gi, 'l');
+  },
+  /**
+   * Hashes an admin token with a given salt. In v0.3.x, salt is the projectId.
+   * @param {string} token
+   * @param {string} salt
+   */
+  hashAdminToken(token, salt) {
+    const hash = crypto.createHmac('sha256', salt);
+    hash.update(token);
+    return hash.digest('hex');
+  },
+};

--- a/packages/server/src/api/storage/sql/migrations/2020030501-admin-token.js
+++ b/packages/server/src/api/storage/sql/migrations/2020030501-admin-token.js
@@ -1,0 +1,32 @@
+/**
+ * @license Copyright 2020 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const StorageMethod = require('../../storage-method');
+
+/* eslint-disable new-cap */
+
+module.exports = {
+  /**
+   * @param {import('sequelize').QueryInterface} queryInterface
+   * @param {typeof import('sequelize')} Sequelize
+   */
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('projects', 'adminToken', {type: Sequelize.STRING(40)});
+    await queryInterface.bulkUpdate(
+      'projects',
+      {adminToken: StorageMethod.generateAdminToken()},
+      {adminToken: null},
+      {type: Sequelize.QueryTypes.BULKUPDATE}
+    );
+  },
+  /**
+   * @param {import('sequelize').QueryInterface} queryInterface
+   */
+  down: async queryInterface => {
+    await queryInterface.removeColumn('projects', 'adminToken');
+  },
+};

--- a/packages/server/src/api/storage/sql/migrations/2020030501-admin-token.js
+++ b/packages/server/src/api/storage/sql/migrations/2020030501-admin-token.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const StorageMethod = require('../../storage-method');
+const {hashAdminToken, generateAdminToken} = require('../../auth.js');
 
 /* eslint-disable new-cap */
 
@@ -15,10 +15,12 @@ module.exports = {
    * @param {typeof import('sequelize')} Sequelize
    */
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.addColumn('projects', 'adminToken', {type: Sequelize.STRING(40)});
+    await queryInterface.addColumn('projects', 'adminToken', {type: Sequelize.STRING(64)});
     await queryInterface.bulkUpdate(
       'projects',
-      {adminToken: StorageMethod.generateAdminToken()},
+      // Because of the useless salt, this will be an invalid admin token that requires resetting
+      // via the wizard command, but our goal is exactly to create an initial token no one can guess.
+      {adminToken: hashAdminToken(generateAdminToken(), '0')},
       {adminToken: null},
       {type: Sequelize.QueryTypes.BULKUPDATE}
     );

--- a/packages/server/src/api/storage/sql/project-model.js
+++ b/packages/server/src/api/storage/sql/project-model.js
@@ -16,6 +16,7 @@ const attributes = {
   slug: {type: Sequelize.STRING(40)},
   externalUrl: {type: Sequelize.STRING(256)},
   token: {type: Sequelize.UUID()},
+  adminToken: {type: Sequelize.STRING(40)},
   createdAt: {type: Sequelize.DATE(6)},
   updatedAt: {type: Sequelize.DATE(6)},
 };

--- a/packages/server/src/api/storage/sql/sql.js
+++ b/packages/server/src/api/storage/sql/sql.js
@@ -620,6 +620,17 @@ class SqlStorageMethod {
     const {statisticModel} = this._sql();
     await statisticModel.update({version: 0}, {where: {projectId, buildId}});
   }
+
+  /**
+   * @param {string} projectId
+   * @return {Promise<string>}
+   */
+  async _resetAdminToken(projectId) {
+    const {projectModel} = this._sql();
+    const newToken = StorageMethod.generateAdminToken();
+    await projectModel.update({adminToken: newToken}, {where: {id: projectId}});
+    return newToken;
+  }
 }
 
 module.exports = SqlStorageMethod;

--- a/packages/server/src/api/storage/sql/sql.js
+++ b/packages/server/src/api/storage/sql/sql.js
@@ -270,7 +270,7 @@ class SqlStorageMethod {
   }
 
   /**
-   * @param {StrictOmit<LHCI.ServerCommand.Project, 'id'|'token'>} unsavedProject
+   * @param {StrictOmit<LHCI.ServerCommand.Project, 'id'|'token'|'adminToken'>} unsavedProject
    * @return {Promise<LHCI.ServerCommand.Project>}
    */
   async createProject(unsavedProject) {
@@ -278,13 +278,18 @@ class SqlStorageMethod {
   }
 
   /**
-   * @param {StrictOmit<LHCI.ServerCommand.Project, 'id'|'token'>} unsavedProject
+   * @param {StrictOmit<LHCI.ServerCommand.Project, 'id'|'token'|'adminToken'>} unsavedProject
    * @return {Promise<LHCI.ServerCommand.Project>}
    */
   async _createProject(unsavedProject) {
     const {projectModel} = this._sql();
     if (unsavedProject.name.length < 4) throw new E422('Project name too short');
-    const project = await projectModel.create({...unsavedProject, token: uuid.v4(), id: uuid.v4()});
+    const project = await projectModel.create({
+      ...unsavedProject,
+      adminToken: StorageMethod.generateAdminToken(),
+      token: uuid.v4(),
+      id: uuid.v4(),
+    });
     return clone(project);
   }
 

--- a/packages/server/src/api/storage/storage-method.js
+++ b/packages/server/src/api/storage/storage-method.js
@@ -13,6 +13,7 @@ const {
   definitions: statisticDefinitions,
   VERSION: STATISTIC_VERSION,
 } = require('../statistic-definitions.js');
+const {E404} = require('../express-utils.js');
 
 class StorageMethod {
   /**
@@ -133,6 +134,16 @@ class StorageMethod {
   /**
    * @param {string} projectId
    * @param {string} buildId
+   * @return {Promise<void>}
+   */
+  // eslint-disable-next-line no-unused-vars
+  async deleteBuild(projectId, buildId) {
+    throw new Error('Unimplemented');
+  }
+
+  /**
+   * @param {string} projectId
+   * @param {string} buildId
    * @param {LHCI.ServerCommand.GetRunsOptions} [options]
    * @return {Promise<LHCI.ServerCommand.Run[]>}
    */
@@ -217,7 +228,7 @@ class StorageMethod {
    */
   static async getOrCreateStatistics(storageMethod, projectId, buildId) {
     const build = await storageMethod.findBuildById(projectId, buildId);
-    if (!build) throw new Error('Cannot create statistics for non-existent build');
+    if (!build) throw new E404('No build with that ID');
     // If the build hasn't been sealed yet then we can't compute statistics for it yet.
     if (build.lifecycle !== 'sealed') return [];
 

--- a/packages/server/src/api/storage/storage-method.js
+++ b/packages/server/src/api/storage/storage-method.js
@@ -5,6 +5,7 @@
  */
 'use strict';
 
+const crypto = require('crypto');
 const _ = require('@lhci/utils/src/lodash.js');
 const PRandom = require('@lhci/utils/src/seed-data/prandom.js');
 const {computeRepresentativeRuns} = require('@lhci/utils/src/representative-runs.js');
@@ -63,7 +64,7 @@ class StorageMethod {
   }
 
   /**
-   * @param {StrictOmit<LHCI.ServerCommand.Project, 'id'|'token'>} project
+   * @param {StrictOmit<LHCI.ServerCommand.Project, 'id'|'token'|'adminToken'>} project
    * @return {Promise<LHCI.ServerCommand.Project>}
    */
   // eslint-disable-next-line no-unused-vars
@@ -170,7 +171,7 @@ class StorageMethod {
   }
 
   /**
-   * @param {StrictOmit<LHCI.ServerCommand.Project, 'id'|'token'>} project
+   * @param {StrictOmit<LHCI.ServerCommand.Project, 'id'|'token'|'adminToken'>} project
    * @return {Promise<LHCI.ServerCommand.Project>}
    */
   // eslint-disable-next-line no-unused-vars
@@ -311,7 +312,7 @@ class StorageMethod {
 
   /**
    * @param {StorageMethod} storageMethod
-   * @param {StrictOmit<LHCI.ServerCommand.Project, 'id'|'token'>} unsavedProject
+   * @param {StrictOmit<LHCI.ServerCommand.Project, 'id'|'token'|'adminToken'>} unsavedProject
    */
   static async createProjectWithUniqueSlug(storageMethod, unsavedProject) {
     const maxLength = 40;
@@ -326,6 +327,14 @@ class StorageMethod {
 
     if (existingProject) throw new Error('Unable to generate unique slug');
     return storageMethod._createProject({...unsavedProject, slug});
+  }
+
+  /** Generates a cryptographically psuedorandom alphanumeric string of length 40. @return {string} */
+  static generateAdminToken() {
+    return crypto
+      .randomBytes(30)
+      .toString('base64')
+      .replace(/[^a-z0-9]/gi, 'l');
   }
 
   /**

--- a/packages/server/src/api/storage/storage-method.js
+++ b/packages/server/src/api/storage/storage-method.js
@@ -38,6 +38,15 @@ class StorageMethod {
   }
 
   /**
+   * @param {string} projectId
+   * @return {Promise<void>}
+   */
+  // eslint-disable-next-line no-unused-vars
+  async deleteProject(projectId) {
+    throw new Error('Unimplemented');
+  }
+
+  /**
    * @param {string} token
    * @return {Promise<LHCI.ServerCommand.Project | undefined>}
    */

--- a/packages/server/src/api/storage/storage-method.js
+++ b/packages/server/src/api/storage/storage-method.js
@@ -5,7 +5,6 @@
  */
 'use strict';
 
-const crypto = require('crypto');
 const _ = require('@lhci/utils/src/lodash.js');
 const PRandom = require('@lhci/utils/src/seed-data/prandom.js');
 const {computeRepresentativeRuns} = require('@lhci/utils/src/representative-runs.js');
@@ -356,14 +355,6 @@ class StorageMethod {
 
     if (existingProject) throw new Error('Unable to generate unique slug');
     return storageMethod._createProject({...unsavedProject, slug});
-  }
-
-  /** Generates a cryptographically psuedorandom alphanumeric string of length 40. @return {string} */
-  static generateAdminToken() {
-    return crypto
-      .randomBytes(30)
-      .toString('base64')
-      .replace(/[^a-z0-9]/gi, 'l');
   }
 
   /**

--- a/packages/server/src/api/storage/storage-method.js
+++ b/packages/server/src/api/storage/storage-method.js
@@ -191,6 +191,15 @@ class StorageMethod {
   }
 
   /**
+   * @param {string} projectId
+   * @return {Promise<string>}
+   */
+  // eslint-disable-next-line no-unused-vars
+  async _resetAdminToken(projectId) {
+    throw new Error('Unimplemented');
+  }
+
+  /**
    * @param {StrictOmit<LHCI.ServerCommand.Project, 'id'|'token'|'adminToken'>} project
    * @return {Promise<LHCI.ServerCommand.Project>}
    */

--- a/packages/server/test/server-test-suite.js
+++ b/packages/server/test/server-test-suite.js
@@ -841,6 +841,20 @@ function runTests(state) {
       const runs = await client.getRuns(buildA.projectId, buildA.id);
       expect(runs).toEqual([]);
     });
+
+    it('should delete a project', async () => {
+      client.setAdminToken(projectA.adminToken);
+      await client.deleteProject(buildA.projectId);
+
+      const project = await client.findProjectById(projectA.id);
+      expect(project).toEqual(undefined);
+
+      const buildsA = await client.getBuilds(projectA.id);
+      expect(buildsA).toEqual([]);
+
+      const buildsB = await client.getBuilds(projectB.id);
+      expect(buildsB).toHaveLength(1);
+    });
   });
 }
 

--- a/packages/server/test/server-test-suite.js
+++ b/packages/server/test/server-test-suite.js
@@ -69,7 +69,7 @@ function runTests(state) {
 
     it('should fetch a project by a token', async () => {
       const project = await client.findProjectByToken(projectA.token);
-      expect(project).toEqual(projectA);
+      expect(project).toEqual({...projectA, adminToken: ''});
     });
 
     it('should fetch a project by ID', async () => {

--- a/packages/utils/src/api-client.js
+++ b/packages/utils/src/api-client.js
@@ -200,6 +200,14 @@ class ApiClient {
 
   /**
    * @param {string} projectId
+   * @return {Promise<void>}
+   */
+  async deleteProject(projectId) {
+    return this._delete(`/v1/projects/${projectId}`);
+  }
+
+  /**
+   * @param {string} projectId
    * @param {LHCI.ServerCommand.GetBuildsOptions} [options]
    * @return {Promise<LHCI.ServerCommand.Build[]>}
    */

--- a/packages/utils/src/api-client.js
+++ b/packages/utils/src/api-client.js
@@ -173,7 +173,7 @@ class ApiClient {
   }
 
   /**
-   * @param {StrictOmit<LHCI.ServerCommand.Project, 'id'|'token'>} unsavedProject
+   * @param {StrictOmit<LHCI.ServerCommand.Project, 'id'|'token'|'adminToken'>} unsavedProject
    * @return {Promise<LHCI.ServerCommand.Project>}
    */
   async createProject(unsavedProject) {
@@ -273,7 +273,7 @@ class ApiClient {
   }
 
   /**
-   * @param {StrictOmit<LHCI.ServerCommand.Project, 'id'|'token'>} unsavedProject
+   * @param {StrictOmit<LHCI.ServerCommand.Project, 'id'|'token'|'adminToken'>} unsavedProject
    * @return {Promise<LHCI.ServerCommand.Project>}
    */
   // eslint-disable-next-line no-unused-vars

--- a/packages/utils/src/api-client.js
+++ b/packages/utils/src/api-client.js
@@ -345,6 +345,15 @@ class ApiClient {
     throw new Error('Unimplemented');
   }
 
+  /**
+   * @param {string} projectId
+   * @return {Promise<string>}
+   */
+  // eslint-disable-next-line no-unused-vars
+  async _resetAdminToken(projectId) {
+    throw new Error('Unimplemented');
+  }
+
   async close() {}
 }
 

--- a/packages/utils/src/seed-data/dataset-generator.js
+++ b/packages/utils/src/seed-data/dataset-generator.js
@@ -194,6 +194,7 @@ function createDefaultDataset() {
         name: 'Lighthouse Viewer',
         externalUrl: 'https://travis-ci.org/GoogleChrome/lighthouse',
         token: '',
+        adminToken: '',
         slug: '',
       },
       {
@@ -201,6 +202,7 @@ function createDefaultDataset() {
         name: 'Lighthouse Dashboard',
         externalUrl: 'https://travis-ci.org/GoogleChrome/lighthouse-ci',
         token: '',
+        adminToken: '',
         slug: '',
       },
     ],
@@ -458,6 +460,7 @@ function createLoadTestDataset() {
     name: 'Example',
     externalUrl: 'https://www.example.com',
     token: '',
+    adminToken: '',
     slug: '',
   };
   /** @type {Array<LHCI.ServerCommand.Build>} */

--- a/scripts/recreate-build.js
+++ b/scripts/recreate-build.js
@@ -44,6 +44,7 @@ async function run() {
     slug: '',
     externalUrl: '',
     token: '',
+    adminToken: '',
   };
 
   /** @type {Array<LHCI.ServerCommand.Build>} */

--- a/types/server.d.ts
+++ b/types/server.d.ts
@@ -20,6 +20,7 @@ declare global {
         name: string;
         externalUrl: string;
         token: string;
+        adminToken: string;
         slug: string;
         createdAt?: string;
         updatedAt?: string;

--- a/types/wizard.d.ts
+++ b/types/wizard.d.ts
@@ -8,8 +8,10 @@ declare global {
   namespace LHCI {
     namespace WizardCommand {
       export interface Options {
+        wizard?: 'new-project' | 'reset-admin-token';
         extraHeaders?: Record<string, string>;
         serverBaseUrl?: string;
+        storage?: ServerCommand.StorageOptions;
       }
     }
   }


### PR DESCRIPTION
ref #85 

This PR:

- Adds the `adminToken` discussed in #85 to the project model
- Adds two authenticated routes protected by the admin token (DELETE of builds and projects)
- Adds a new wizard command for directly connecting to the SQL database to reset to a fresh admin token

Next steps:
- ~~Hash the admin token, never store in plaintext (required before merge)~~ DONE
- Add UI that allows a user to enter their admin token
- Add UI to delete builds/projects

~~still a WIP because this token is worth hashing compared to the public one, but pretty much~~ delivers o the server pieces of #85