### PR TITLE
Add HTTP Basic Authentication to server

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,7 +16,7 @@ yarn global add @lhci/cli
 
 ## Commands
 
-All commands support configuration via a JSON file passed in via `--config=./path/to/`. Any argument on the CLI can also be passed in via environment variable. For example, `--config=foo` can be replaced with `LH_RC_FILE=foo`. Learn more about [configuration](./configuration.md).
+All commands support configuration via a JSON file passed in via `--config=./path/to/`. Any argument on the CLI can also be passed in via environment variable. For example, `--config=foo` can be replaced with `LH_CONFIG=foo`. Learn more about [configuration](./configuration.md).
 
 ### `healthcheck`
 
@@ -296,20 +296,25 @@ Run Lighthouse CI server
 Options:
   --help                                 Show help                     [boolean]
   --version                              Show version number           [boolean]
-  --config                               Path to JSON config file
+  --no-lighthouserc                      Disables automatic usage of a
+                                         .lighthouserc file.           [boolean]
   --logLevel        [string] [choices: "silent", "verbose"] [default: "verbose"]
   --port, -p                                            [number] [default: 9001]
   --storage.sqlDialect
-                    [string] [choices: "sqlite", "postgres", "mysql"] [default: "sqlite"]
+           [string] [choices: "sqlite", "postgres", "mysql"] [default: "sqlite"]
   --storage.sqlDatabasePath              The path to a SQLite database on disk.
-  --storage.sqlConnectionUrl             The connection url to a postgres
-                                         database.
+  --storage.sqlConnectionUrl             The connection url to a postgres or
+                                         mysql database.
   --storage.sqlConnectionSsl             Whether the SQL connection should force
                                          use of SSL   [boolean] [default: false]
   --storage.sqlDangerouslyResetDatabase  Whether to force the database to the
                                          required schema. WARNING: THIS WILL
                                          DELETE ALL DATA
                                                       [boolean] [default: false]
+  --basicAuth.username                   The username to protect the server with
+                                         HTTP Basic Authentication.     [string]
+  --basicAuth.password                   The password to protect the server with
+                                         HTTP Basic Authentication.     [string]
 ```
 
 **Examples**
@@ -317,6 +322,7 @@ Options:
 ```bash
 lhci server --storage.sqlDatabasePath=./lhci.db
 lhci server --storage.sqlDialect=postgres --storage.sqlConnectionUrl="postgres://user@localhost/lighthouse_ci_db"
+lhci server --storage.sqlDatabasePath=./lhci.db --basicAuth.username="customuser" --basicAuth.password="LighthouseRocks"
 ```
 
 ## Configuration

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -96,6 +96,7 @@ Runs an interactive step-by-step wizard to create a new project on the LHCI serv
 
 ```bash
 lhci wizard
+lhci wizard --basicAuth.username="customuser" --basicAuth.password="LighthouseRocks"
 ```
 
 ---
@@ -227,7 +228,8 @@ Options:
 lhci upload --config=./lighthouserc.json
 lhci upload --target=temporary-public-storage
 lhci upload --serverBaseUrl=http://lhci.my-custom-domain.com/
-lhci upload --extraHeaders.Authorization='Basic dGVzdDoxMjPCow=='
+lhci upload --extraHeaders.Authorization='Bearer X92sEo3n1J1F0k1E9'
+lhci upload --basicAuth.username="customuser" --basicAuth.password="LighthouseRocks"
 lhci upload --githubToken="$MY_ENTERPRISE_GITHUB_TOKEN" --githubApiHost="https://custom-github-server.example.com/api/v3"
 ```
 

--- a/packages/cli/src/collect/fallback-server.js
+++ b/packages/cli/src/collect/fallback-server.js
@@ -54,7 +54,12 @@ class FallbackServer {
   async close() {
     if (!this._server) return;
     const server = this._server;
-    return new Promise((resolve, reject) => server.close(err => (err ? reject(err) : resolve())));
+    return new Promise((resolve, reject) =>
+      server.close(
+        /** @param {Error|undefined} err */
+        err => (err ? reject(err) : resolve())
+      )
+    );
   }
 
   /** @return {string[]} */

--- a/packages/cli/src/healthcheck/healthcheck.js
+++ b/packages/cli/src/healthcheck/healthcheck.js
@@ -20,6 +20,9 @@ const PASS_ICON = '✅';
 const WARN_ICON = '⚠️ ';
 const FAIL_ICON = '❌';
 
+/** @param {LHCI.YargsOptions} options @return {ApiClient} */
+const getApiClient = options => new ApiClient({...options, rootURL: options.serverBaseUrl || ''});
+
 /**
  * @param {import('yargs').Argv} yargs
  */
@@ -83,8 +86,7 @@ const checks = [
     failureLabel: 'LHCI server not reachable',
     // the test only makes sense if they've configured an LHCI server
     shouldTest: opts => Boolean(opts.serverBaseUrl && opts.token),
-    test: async ({serverBaseUrl = ''}) =>
-      (await new ApiClient({rootURL: serverBaseUrl}).getVersion()).length > 0,
+    test: async opts => (await getApiClient(opts).getVersion()).length > 0,
   },
   {
     id: 'lhciServer',
@@ -92,9 +94,9 @@ const checks = [
     failureLabel: 'LHCI server token invalid',
     // the test only makes sense if they've configured an LHCI server
     shouldTest: opts => Boolean(opts.serverBaseUrl && opts.token),
-    test: async ({serverBaseUrl = '', token = ''}) => {
-      const client = new ApiClient({rootURL: serverBaseUrl});
-      const project = await client.findProjectByToken(token);
+    test: async opts => {
+      const client = getApiClient(opts);
+      const project = await client.findProjectByToken(opts.token || '');
       return Boolean(project);
     },
   },
@@ -104,9 +106,9 @@ const checks = [
     failureLabel: 'LHCI server non-unique build for this hash',
     // the test only makes sense if they've configured an LHCI server
     shouldTest: opts => Boolean(opts.serverBaseUrl && opts.token),
-    test: async ({serverBaseUrl = '', token = ''}) => {
-      const client = new ApiClient({rootURL: serverBaseUrl});
-      const project = await client.findProjectByToken(token);
+    test: async opts => {
+      const client = getApiClient(opts);
+      const project = await client.findProjectByToken(opts.token || '');
       if (!project) return true;
       const builds = await client.getBuilds(project.id, {
         branch: getCurrentBranch(),

--- a/packages/cli/src/server/server.js
+++ b/packages/cli/src/server/server.js
@@ -47,6 +47,14 @@ function buildCommand(yargs) {
       type: 'boolean',
       default: false,
     },
+    'basicAuth.username': {
+      type: 'string',
+      description: 'The username to protect the server with HTTP Basic Authentication.',
+    },
+    'basicAuth.password': {
+      type: 'string',
+      description: 'The password to protect the server with HTTP Basic Authentication.',
+    },
   });
 }
 

--- a/packages/cli/src/upload/upload.js
+++ b/packages/cli/src/upload/upload.js
@@ -89,6 +89,16 @@ function buildCommand(yargs) {
     extraHeaders: {
       description: '[lhci only] Extra headers to use when making API requests to the LHCI server.',
     },
+    'basicAuth.username': {
+      type: 'string',
+      description:
+        '[lhci only] The username to use on a server protected with HTTP Basic Authentication.',
+    },
+    'basicAuth.password': {
+      type: 'string',
+      description:
+        '[lhci only] The password to use on a server protected with HTTP Basic Authentication.',
+    },
     serverBaseUrl: {
       description: '[lhci only] The base URL of the LHCI server where results will be saved.',
       default: 'http://localhost:9001/',
@@ -334,7 +344,7 @@ function buildTemporaryStorageLink(compareUrl, urlAudited, previousUrlMap) {
 async function runLHCITarget(options) {
   if (!options.token) throw new Error('Must provide token for LHCI target');
 
-  const api = new ApiClient({rootURL: options.serverBaseUrl, extraHeaders: options.extraHeaders});
+  const api = new ApiClient({...options, rootURL: options.serverBaseUrl});
 
   const project = await api.findProjectByToken(options.token);
   if (!project) {

--- a/packages/cli/src/wizard/wizard.js
+++ b/packages/cli/src/wizard/wizard.js
@@ -44,8 +44,8 @@ async function runNewProjectWizard(options) {
   ]);
 
   const api = new ApiClient({
+    ...options,
     rootURL: responses.serverBaseUrl || options.serverBaseUrl,
-    extraHeaders: options.extraHeaders || {},
   });
   const project = await api.createProject({
     name: responses.projectName,

--- a/packages/cli/test/autorun-start-server.test.js
+++ b/packages/cli/test/autorun-start-server.test.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-// jest.retryTimes(3);
+jest.retryTimes(3);
 
 /* eslint-env jest */
 

--- a/packages/cli/test/test-utils.js
+++ b/packages/cli/test/test-utils.js
@@ -55,7 +55,7 @@ async function withTmpDir(fn) {
   rimraf.sync(tmpDir);
 }
 
-async function startServer(sqlFile) {
+async function startServer(sqlFile, extraArgs = []) {
   if (!sqlFile) {
     sqlFile = getSqlFilePath();
   }
@@ -66,6 +66,7 @@ async function startServer(sqlFile) {
     'server',
     '-p=0',
     `--storage.sqlDatabasePath=${sqlFile}`,
+    ...extraArgs,
   ]);
   serverProcess.stdout.on('data', chunk => (stdout += chunk.toString()));
 

--- a/packages/cli/test/wizard.test.js
+++ b/packages/cli/test/wizard.test.js
@@ -1,0 +1,145 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+jest.retryTimes(3);
+
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const log = require('lighthouse-logger');
+const ApiClient = require('../../utils/src/api-client.js');
+const {startServer, safeDeleteFile, runWizardCLI} = require('./test-utils.js');
+
+describe('wizard CLI', () => {
+  let server;
+  let projectToken;
+  let projectAdminToken;
+
+  beforeAll(async () => {
+    server = await startServer();
+  });
+
+  afterAll(async () => {
+    if (server) {
+      server.process.kill();
+      await safeDeleteFile(server.sqlFile);
+    }
+  });
+
+  describe('new-project', () => {
+    it('should create a new project', async () => {
+      const {stdout, stderr, status} = await runWizardCLI(
+        [],
+        [
+          '', // Just ENTER key to select "new-project"
+          `http://localhost:${server.port}`, // The base URL to talk to
+          'AwesomeCIProjectName', // Project name
+          'https://example.com', // External build URL
+        ]
+      );
+
+      // Extract the regular token
+      expect(stdout).toContain('Use token');
+      const tokenSentence = stdout
+        .match(/Use token [\s\S]+/im)[0]
+        .replace(log.bold, '')
+        .replace(log.reset, '');
+      projectToken = tokenSentence.match(/Use token ([\w-]+)/)[1];
+
+      // Extract the admin token
+      expect(stdout).toContain('Use admin token');
+      const adminSentence = stdout
+        .match(/Use admin token [\s\S]+/im)[0]
+        .replace(log.bold, '')
+        .replace(log.reset, '');
+      projectAdminToken = adminSentence.match(/Use admin token (\w+)/)[1];
+
+      expect(stderr).toEqual('');
+      expect(status).toEqual(0);
+    }, 30000);
+
+    it('should create a new project with config file', async () => {
+      server.process.kill();
+      server = await startServer(server.sqlFile, ['--basicAuth.password=lighthouse']);
+
+      const wizardTempConfigFile = {
+        ci: {
+          wizard: {
+            serverBaseUrl: `http://localhost:${server.port}`,
+            basicAuth: {password: 'lighthouse'},
+          },
+        },
+      };
+      const tmpFolder = fs.mkdtempSync(`${os.tmpdir()}${path.sep}`);
+      const wizardRcFile = `${tmpFolder}/wizard.json`;
+      fs.writeFileSync(wizardRcFile, JSON.stringify(wizardTempConfigFile), {encoding: 'utf8'});
+
+      const {stdout, stderr, status} = await runWizardCLI(
+        [`--config=${wizardRcFile}`],
+        [
+          '', // Just ENTER key to select "new-project"
+          '', // Just ENTER key to use serverBaseUrl from config file
+          'OtherCIProjectName', // Project name
+          'https://example.com', // External build URL
+        ]
+      );
+
+      expect(stdout).toContain(`http://localhost:${server.port}`);
+      expect(stderr).toEqual('');
+      expect(status).toEqual(0);
+    }, 30000);
+  });
+
+  describe('reset-admin-token', () => {
+    it('should reset the admin token', async () => {
+      const storage = {storageMethod: 'sql', sqlDialect: 'sqlite', sqlDatabasePath: server.sqlFile};
+      const wizardTempConfigFile = {ci: {wizard: {wizard: 'reset-admin-token', storage}}};
+      const tmpFolder = fs.mkdtempSync(`${os.tmpdir()}${path.sep}`);
+      const wizardRcFile = `${tmpFolder}/wizard.json`;
+      fs.writeFileSync(wizardRcFile, JSON.stringify(wizardTempConfigFile), {encoding: 'utf8'});
+
+      const {stdout, stderr, status} = await runWizardCLI(
+        [`--config=${wizardRcFile}`],
+        [
+          '', // Just ENTER key to select the first project
+          'AwesomeCIProjectName', // Confirm project name
+        ],
+        {inputWaitCondition: 'Which project'}
+      );
+
+      // Extract the admin token
+      expect(stdout).toContain('Use admin token');
+      const adminSentence = stdout
+        .match(/Use admin token [\s\S]+/im)[0]
+        .replace(log.bold, '')
+        .replace(log.reset, '');
+      const oldAdminToken = projectAdminToken;
+      projectAdminToken = adminSentence.match(/Use admin token (\w+)/)[1];
+
+      expect(stderr).toEqual('');
+      expect(status).toEqual(0);
+
+      const client = new ApiClient({
+        rootURL: `http://localhost:${server.port}`,
+        basicAuth: {password: 'lighthouse'},
+      });
+      const project = await client.findProjectByToken(projectToken);
+
+      client.setAdminToken(oldAdminToken);
+      expect(await client.getProjects()).toHaveLength(2);
+      await expect(client.deleteProject(project.id)).rejects.toBeDefined();
+      expect(await client.getProjects()).toHaveLength(2);
+
+      client.setAdminToken(projectAdminToken);
+      expect(await client.getProjects()).toHaveLength(2);
+      await client.deleteProject(project.id);
+      expect(await client.getProjects()).toHaveLength(1);
+    }, 30000);
+  });
+});

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,6 +24,7 @@
     "body-parser": "^1.18.3",
     "compression": "^1.7.4",
     "express": "^4.16.4",
+    "express-basic-auth": "^1.2.0",
     "morgan": "^1.9.1",
     "sequelize": "^4.44.3",
     "umzug": "^2.2.0",

--- a/packages/server/src/api/express-utils.js
+++ b/packages/server/src/api/express-utils.js
@@ -5,6 +5,7 @@
  */
 'use strict';
 
+const basicAuth = require('express-basic-auth');
 const {hashAdminToken} = require('./storage/auth.js');
 
 class E404 extends Error {}
@@ -52,6 +53,17 @@ module.exports = {
           res.send(JSON.stringify({message: err.message}));
         });
     };
+  },
+  /**
+   * @param {{options: LHCI.ServerCommand.Options}} context
+   * @return {import('express-serve-static-core').RequestHandler|undefined}
+   */
+  createBasicAuthMiddleware(context) {
+    if (!context.options.basicAuth) return undefined;
+    const {username = 'lhci', password} = context.options.basicAuth;
+    if (!password) return undefined;
+
+    return basicAuth({users: {[username]: password}, challenge: true});
   },
   /**
    * @param {Error} err

--- a/packages/server/src/api/express-utils.js
+++ b/packages/server/src/api/express-utils.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const basicAuth = require('express-basic-auth');
+const ApiClient = require('@lhci/utils/src/api-client.js');
 const {hashAdminToken} = require('./storage/auth.js');
 
 class E404 extends Error {}
@@ -60,7 +61,7 @@ module.exports = {
    */
   createBasicAuthMiddleware(context) {
     if (!context.options.basicAuth) return undefined;
-    const {username = 'lhci', password} = context.options.basicAuth;
+    const {username = ApiClient.DEFAULT_BASIC_AUTH_USERNAME, password} = context.options.basicAuth;
     if (!password) return undefined;
 
     return basicAuth({users: {[username]: password}, challenge: true});

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -23,7 +23,7 @@ const DIST_FOLDER = path.join(__dirname, '../dist');
 
 /**
  * @param {LHCI.ServerCommand.Options} options
- * @return {Promise<{app: Parameters<typeof createHttpServer>[0], storageMethod: StorageMethod}>}
+ * @return {Promise<{app: Parameters<typeof createHttpServer>[1], storageMethod: StorageMethod}>}
  */
 async function createApp(options) {
   const {storage} = options;

--- a/packages/server/test/basic-auth-server.test.js
+++ b/packages/server/test/basic-auth-server.test.js
@@ -1,0 +1,80 @@
+/**
+ * @license Copyright 2020 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+const path = require('path');
+const runTests = require('./server-test-suite.js').runTests;
+const runServer = require('../src/server.js').createServer;
+const {safeDeleteFile} = require('../../cli/test/test-utils.js');
+
+describe('sqlite server (authenticated)', () => {
+  const state = {
+    port: undefined,
+    closeServer: undefined,
+  };
+
+  const dbPath = path.join(__dirname, 'server-auth-test.tmp.sql');
+
+  beforeAll(async () => {
+    await safeDeleteFile(dbPath);
+
+    const {port, close, storageMethod} = await runServer({
+      logLevel: 'silent',
+      port: 0,
+      storage: {
+        storageMethod: 'sql',
+        sqlDialect: 'sqlite',
+        sqlDatabasePath: dbPath,
+      },
+      basicAuth: {
+        username: 'foobar',
+        password: 'ICanBeYourLighthouse',
+      },
+    });
+
+    const basicAuthEncoded = Buffer.from('foobar:ICanBeYourLighthouse').toString('base64');
+    state.port = port;
+    state.closeServer = close;
+    state.storageMethod = storageMethod;
+    state.extraHeaders = {Authorization: `Basic ${basicAuthEncoded}`};
+  });
+
+  afterAll(async () => {
+    await state.closeServer();
+    await safeDeleteFile(dbPath);
+  });
+
+  runTests(state);
+
+  describe('basic authentication', () => {
+    const routes = ['/', '/v1/projects', '/app', '/version'];
+    for (const route of routes) {
+      it(`should reject unauthorized requests for ${route}`, async () => {
+        const response = await fetch(`http://localhost:${state.port}${route}`);
+        expect(response.status).toEqual(401);
+      });
+
+      it(`should reject incorrect login requests for ${route}`, async () => {
+        const incorrectBasicAuth = Buffer.from('lhci:password').toString('base64');
+        const response = await fetch(`http://localhost:${state.port}${route}`, {
+          headers: {Authorization: `Basic ${incorrectBasicAuth}`},
+        });
+        expect(response.status).toEqual(401);
+      });
+
+      it(`should allow authorized requests for ${route}`, async () => {
+        const response = await fetch(`http://localhost:${state.port}${route}`, {
+          headers: state.extraHeaders,
+        });
+        expect(response.status).toEqual(200);
+        const body = await response.text();
+        expect(body.length).toBeGreaterThan(4);
+      });
+    }
+  });
+});

--- a/packages/server/test/basic-auth-server.test.js
+++ b/packages/server/test/basic-auth-server.test.js
@@ -8,6 +8,7 @@
 /* eslint-env jest */
 
 const path = require('path');
+const fetch = require('isomorphic-fetch');
 const runTests = require('./server-test-suite.js').runTests;
 const runServer = require('../src/server.js').createServer;
 const {safeDeleteFile} = require('../../cli/test/test-utils.js');

--- a/packages/server/test/server-test-suite.js
+++ b/packages/server/test/server-test-suite.js
@@ -27,7 +27,7 @@ function runTests(state) {
 
   beforeAll(() => {
     rootURL = `http://localhost:${state.port}`;
-    client = new ApiClient({rootURL});
+    client = new ApiClient({rootURL, extraHeaders: state.extraHeaders});
   });
 
   describe('/version', () => {
@@ -735,13 +735,16 @@ function runTests(state) {
   });
 
   describe('error handling', () => {
+    // Defer the use of `state.extraHeaders` because they're initialized in a `beforeAll` block
+    const fetchOptions = () => ({headers: state.extraHeaders});
+
     it('should return 404 in the case of missing data by id', async () => {
-      const response = await fetch(`${rootURL}/v1/projects/missing`);
+      const response = await fetch(`${rootURL}/v1/projects/missing`, fetchOptions());
       expect(response.status).toEqual(404);
     });
 
     it('should return 404 in the case of missing data by slug', async () => {
-      const response = await fetch(`${rootURL}/v1/projects/slug:missing`);
+      const response = await fetch(`${rootURL}/v1/projects/slug:missing`, fetchOptions());
       expect(response.status).toEqual(404);
     });
 

--- a/packages/utils/src/api-client.js
+++ b/packages/utils/src/api-client.js
@@ -8,9 +8,12 @@
 const URL = require('url').URL;
 const fetch = require('isomorphic-fetch');
 
+/** @type {(s: string) => string} */
+const btoa = typeof window === 'undefined' ? s => Buffer.from(s).toString('base64') : window.btoa;
+
 class ApiClient {
   /**
-   * @param {{rootURL: string, fetch?: import('isomorphic-fetch'), URL?: typeof import('url').URL, extraHeaders?: Record<string, string>}} options
+   * @param {{rootURL: string, fetch?: import('isomorphic-fetch'), URL?: typeof import('url').URL, extraHeaders?: Record<string, string>, basicAuth?: LHCI.ServerCommand.Options['basicAuth']}} options
    */
   constructor(options) {
     this._rootURL = options.rootURL;
@@ -18,6 +21,11 @@ class ApiClient {
     this._extraHeaders = options.extraHeaders || {};
     this._fetch = options.fetch || fetch;
     this._URL = options.URL || URL;
+
+    if (options.basicAuth && options.basicAuth.password) {
+      const {username = ApiClient.DEFAULT_BASIC_AUTH_USERNAME, password} = options.basicAuth;
+      this._extraHeaders.Authorization = `Basic ${btoa(`${username}:${password}`)}`;
+    }
 
     /** @type {LHCI.ServerCommand.StorageMethod} */
     const typecheck = this; // eslint-disable-line no-unused-vars
@@ -355,6 +363,10 @@ class ApiClient {
   }
 
   async close() {}
+
+  static get DEFAULT_BASIC_AUTH_USERNAME() {
+    return 'lhci';
+  }
 }
 
 module.exports = ApiClient;

--- a/packages/utils/src/api-client.js
+++ b/packages/utils/src/api-client.js
@@ -9,7 +9,7 @@ const URL = require('url').URL;
 const fetch = require('isomorphic-fetch');
 
 /** @type {(s: string) => string} */
-const btoa = typeof window === 'undefined' ? s => Buffer.from(s).toString('base64') : window.btoa;
+const btoa = typeof window === 'undefined' ? s => Buffer.from(s).toString('base64') : window.btoa; // eslint-disable-line no-undef
 
 class ApiClient {
   /**

--- a/scripts/test-lh-report.sh
+++ b/scripts/test-lh-report.sh
@@ -12,7 +12,7 @@ node lighthouse-cli/test/fixtures/static-server.js &
 yarn start http://localhost:10200/dobetterweb/dbw_tester.html --chrome-flags="--headless" --output-path=./lighthouse-ci/ci-test.report.html
 
 cd ./lighthouse-ci
-export LHCI_RC_FILE="./test/fixtures/lighthouserc.json"
+export LHCI_CONFIG="./test/fixtures/lighthouserc.json"
 yarn start server &
 yarn start collect --url=http://localhost:10200/lighthouse-ci/ci-test.report.html
 yarn start assert

--- a/types/server.d.ts
+++ b/types/server.d.ts
@@ -163,6 +163,10 @@ declare global {
         logLevel: 'silent' | 'verbose';
         port: number;
         storage: StorageOptions;
+        basicAuth?: {
+          username?: string;
+          password?: string;
+        };
       }
     }
   }

--- a/types/upload.d.ts
+++ b/types/upload.d.ts
@@ -14,6 +14,7 @@ declare global {
         token?: string;
         ignoreDuplicateBuildFailure?: boolean;
         uploadUrlMap?: boolean;
+        basicAuth?: ServerCommand.Options['basicAuth'];
         extraHeaders?: Record<string, string>;
         githubToken?: string;
         githubApiHost?: string;

--- a/types/wizard.d.ts
+++ b/types/wizard.d.ts
@@ -10,6 +10,7 @@ declare global {
       export interface Options {
         wizard?: 'new-project' | 'reset-admin-token';
         extraHeaders?: Record<string, string>;
+        basicAuth?: ServerCommand.Options['basicAuth'];
         serverBaseUrl?: string;
         storage?: ServerCommand.StorageOptions;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5136,7 +5136,7 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-basic-auth@~2.0.0:
+basic-auth@^2.0.1, basic-auth@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
   integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
@@ -8611,6 +8611,13 @@ expect@^24.9.0:
     jest-matcher-utils "^24.9.0"
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
+
+express-basic-auth@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/express-basic-auth/-/express-basic-auth-1.2.0.tgz#a1d40b07721376ba916e73571a60969211224808"
+  integrity sha512-iJ0h1Gk6fZRrFmO7tP9nIbxwNgCUJASfNj5fb0Hy15lGtbqqsxpt7609+wq+0XlByZjXmC/rslWQtnuSTVRIcg==
+  dependencies:
+    basic-auth "^2.0.1"
 
 express@^4.16.4:
   version "4.16.4"
@@ -12550,7 +12557,7 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lighthouse-logger@^1.0.0, lighthouse-logger@^1.2.0:
+lighthouse-logger@1.2.0, lighthouse-logger@^1.0.0, lighthouse-logger@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/lighthouse-logger/-/lighthouse-logger-1.2.0.tgz#b76d56935e9c137e86a04741f6bb9b2776e886ca"
   integrity sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==


### PR DESCRIPTION
- adds optional HTTP Basic authentication to the server
- adds basic auth credential support to the healthcheck/upload/wizard CLI commands (can be used whether LHCI or a proxy implements basic auth)
- more tests for wizard and healthcheck flows around connecting to a server with options

**Sample Usage**

```
lhci server --basicAuth.password="LighthouseRocks"
lhci upload --basicAuth.password="LighthouseRocks"
```


closes #85 (for real this time 😄 )