### PR TITLE
feat(cli): add API-version compatibility to healthcheck

### DIFF
--- a/packages/cli/src/healthcheck/healthcheck.js
+++ b/packages/cli/src/healthcheck/healthcheck.js
@@ -15,6 +15,7 @@ const {
   getGitHubRepoSlug,
 } = require('@lhci/utils/src/build-context.js');
 const {loadSavedLHRs} = require('@lhci/utils/src/saved-reports.js');
+const pkg = require('../../package.json');
 
 const PASS_ICON = '✅';
 const WARN_ICON = '⚠️ ';
@@ -87,6 +88,15 @@ const checks = [
     // the test only makes sense if they've configured an LHCI server
     shouldTest: opts => Boolean(opts.serverBaseUrl && opts.token),
     test: async opts => (await getApiClient(opts).getVersion()).length > 0,
+  },
+  {
+    id: 'lhciServer',
+    label: 'LHCI server API-compatible',
+    failureLabel: 'LHCI server not API-compatible',
+    // the test only makes sense if they've configured an LHCI server
+    shouldTest: opts => Boolean(opts.serverBaseUrl && opts.token),
+    test: async opts =>
+      ApiClient.isApiVersionCompatible(pkg.version, await getApiClient(opts).getVersion()),
   },
   {
     id: 'lhciServer',

--- a/packages/cli/test/autorun-start-server.test.js
+++ b/packages/cli/test/autorun-start-server.test.js
@@ -5,8 +5,6 @@
  */
 'use strict';
 
-jest.retryTimes(3);
-
 /* eslint-env jest */
 
 const fs = require('fs');
@@ -105,6 +103,7 @@ describe('Lighthouse CI autorun CLI with startServerCommand', () => {
       ⚠️   GitHub token not set
       ✅  Ancestor hash determinable
       ✅  LHCI server reachable
+      ✅  LHCI server API-compatible
       ✅  LHCI server token valid
       ✅  LHCI server unique build for this hash
       Healthcheck passed!

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -132,6 +132,7 @@ describe('Lighthouse CI CLI', () => {
         ⚠️   GitHub token not set
         ✅  Ancestor hash determinable
         ✅  LHCI server reachable
+        ✅  LHCI server API-compatible
         ✅  LHCI server token valid
         ✅  LHCI server unique build for this hash
         Healthcheck passed!
@@ -156,6 +157,7 @@ describe('Lighthouse CI CLI', () => {
         ❌  GitHub token not set
         ✅  Ancestor hash determinable
         ✅  LHCI server reachable
+        ✅  LHCI server API-compatible
         ✅  LHCI server token valid
         ✅  LHCI server unique build for this hash
         Healthcheck failed!

--- a/packages/utils/src/api-client.js
+++ b/packages/utils/src/api-client.js
@@ -375,6 +375,27 @@ class ApiClient {
   static get DEFAULT_BASIC_AUTH_USERNAME() {
     return 'lhci';
   }
+
+  /**
+   * Computes whether the two version strings are API-version compatible.
+   * For now this is just semver, but could eventually take more into account.
+   * @param {string} versionA
+   * @param {string} versionB
+   */
+  static isApiVersionCompatible(versionA, versionB) {
+    const partsA = versionA.split('.');
+    const partsB = versionB.split('.');
+    if (partsA.length < 3 || partsB.length < 3) return false;
+
+    let majorVersionA = partsA[0];
+    let majorVersionB = partsB[0];
+    if (majorVersionA !== majorVersionB) return false;
+
+    if (majorVersionA === '0') majorVersionA = partsA[1];
+    if (majorVersionB === '0') majorVersionB = partsB[1];
+
+    return majorVersionA === majorVersionB;
+  }
 }
 
 module.exports = ApiClient;

--- a/packages/utils/test/api-client.test.js
+++ b/packages/utils/test/api-client.test.js
@@ -55,4 +55,29 @@ describe('Lighthouse CI API Client', () => {
       );
     });
   });
+
+  describe('#isApiVersionCompatible', () => {
+    const isCompatible = (s1, s2) => ApiClient.isApiVersionCompatible(s1, s2);
+
+    it('should recognize compatible versions', () => {
+      expect(isCompatible('0.0.1', '0.0.2')).toBe(true);
+      expect(isCompatible('1.0.1', '1.4.2')).toBe(true);
+      expect(isCompatible('2.1.1-alpha.1', '2.0.0')).toBe(true);
+      expect(isCompatible('0.3.1', '0.3.2')).toBe(true);
+      expect(isCompatible('0.0.1', '0.0.2')).toBe(true);
+      expect(isCompatible('0.0.1', '0.0.2')).toBe(true);
+    });
+
+    it('should recognize incompatible versions', () => {
+      expect(isCompatible('1.0.0', '2.0.0')).toBe(false);
+      expect(isCompatible('0.4.1', '0.3.2')).toBe(false);
+      expect(isCompatible('0.1.1', '1.0.2')).toBe(false);
+      expect(isCompatible('2.1.1-alpha.1', '1.0.2')).toBe(false);
+    });
+
+    it('should return false on invalid versions', () => {
+      expect(isCompatible('0.1', '0.1')).toBe(false);
+      expect(isCompatible('vtwo', 'vtwo')).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
Will now fail autorun when trying to upload 0.3.x results to a 0.4.x server and viceversa.

ref #119 