### PR TITLE
fix(cli): tweak format of assertion results

### DIFF
--- a/packages/cli/src/assert/assert.js
+++ b/packages/cli/src/assert/assert.js
@@ -77,7 +77,7 @@ async function runCommand(options) {
       return levelA.localeCompare(levelB) || auditIdA.localeCompare(auditIdB);
     });
 
-    process.stderr.write(`${sortedResults.length} result(s) for ${log.bold}${url}${log.reset}\n`);
+    process.stderr.write(`${sortedResults.length} result(s) for ${log.bold}${url}${log.reset} :\n`);
 
     for (const result of sortedResults) {
       const {level, passed, auditId} = result;
@@ -90,12 +90,10 @@ async function runCommand(options) {
       const namePart = `${log.bold}${result.name}${log.reset}`;
 
       const auditTitlePart = result.auditTitle || '';
-      const documentationPart = result.auditDocumentationLink
-        ? `Documentation: ${result.auditDocumentationLink}`
-        : '';
+      const documentationPart = result.auditDocumentationLink || '';
       const titleAndDocs = [auditTitlePart, documentationPart]
         .filter(Boolean)
-        .map(s => `     ` + s)
+        .map(s => `       ` + s)
         .join('\n');
       const humanFriendlyParts = titleAndDocs ? `\n${titleAndDocs}\n` : '';
 

--- a/packages/cli/test/autorun-start-server.test.js
+++ b/packages/cli/test/autorun-start-server.test.js
@@ -69,11 +69,11 @@ describe('Lighthouse CI autorun CLI with startServerCommand', () => {
     expect(stderr).toMatchInlineSnapshot(`
       "Checking assertions against 1 URL(s), 1 total run(s)
 
-      1 result(s) for [1mhttp://localhost:XXXX/[0m
+      1 result(s) for [1mhttp://localhost:XXXX/[0m :
 
         [31mX[0m  [1mviewport[0m failure for [1mminScore[0m assertion
-           Does not have a \`<meta name=\\"viewport\\">\` tag with \`width\` or \`initial-scale\`
-           Documentation: https://web.dev/viewport
+             Does not have a \`<meta name=\\"viewport\\">\` tag with \`width\` or \`initial-scale\`
+             https://web.dev/viewport
 
               expected: >=[32m1[0m
                  found: [31m0[0m

--- a/packages/cli/test/autorun-static-dir.test.js
+++ b/packages/cli/test/autorun-static-dir.test.js
@@ -48,11 +48,11 @@ describe('Lighthouse CI autorun CLI', () => {
     expect(stderr).toMatchInlineSnapshot(`
       "Checking assertions against 1 URL(s), 2 total run(s)
 
-      1 result(s) for [1mhttp://localhost:XXXX/good.html[0m
+      1 result(s) for [1mhttp://localhost:XXXX/good.html[0m :
 
         [31mX[0m  [1mviewport[0m failure for [1mminScore[0m assertion
-           Does not have a \`<meta name=\\"viewport\\">\` tag with \`width\` or \`initial-scale\`
-           Documentation: https://web.dev/viewport
+             Does not have a \`<meta name=\\"viewport\\">\` tag with \`width\` or \`initial-scale\`
+             https://web.dev/viewport
 
               expected: >=[32m1[0m
                  found: [31m0[0m

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -311,11 +311,11 @@ describe('Lighthouse CI CLI', () => {
       expect(stderr).toMatchInlineSnapshot(`
         "Checking assertions against 1 URL(s), 2 total run(s)
 
-        1 result(s) for [1mhttp://localhost:XXXX/app/[0m
+        1 result(s) for [1mhttp://localhost:XXXX/app/[0m :
 
           [31mX[0m  [1mworks-offline[0m failure for [1mminScore[0m assertion
-             Current page does not respond with a 200 when offline
-             Documentation: https://web.dev/works-offline
+               Current page does not respond with a 200 when offline
+               https://web.dev/works-offline
 
                 expected: >=[32m1[0m
                    found: [31m0[0m
@@ -340,11 +340,11 @@ describe('Lighthouse CI CLI', () => {
       expect(stderr).toMatchInlineSnapshot(`
         "Checking assertions against 1 URL(s), 2 total run(s)
 
-        1 result(s) for [1mhttp://localhost:XXXX/app/[0m
+        1 result(s) for [1mhttp://localhost:XXXX/app/[0m :
 
           [31mX[0m  [1mperformance-budget[0m.script.size failure for [1mmaxNumericValue[0m assertion
-             Performance budget
-             Documentation: https://developers.google.com/web/tools/lighthouse/audits/budgets
+               Performance budget
+               https://developers.google.com/web/tools/lighthouse/audits/budgets
 
                 expected: <=[32mXXXX[0m
                    found: [31mXXXX[0m
@@ -363,11 +363,11 @@ describe('Lighthouse CI CLI', () => {
       expect(stderr).toMatchInlineSnapshot(`
         "Checking assertions against 1 URL(s), 2 total run(s)
 
-        1 result(s) for [1mhttp://localhost:XXXX/app/[0m
+        1 result(s) for [1mhttp://localhost:XXXX/app/[0m :
 
           [31mX[0m  [1mworks-offline[0m failure for [1mminScore[0m assertion
-             Current page does not respond with a 200 when offline
-             Documentation: https://web.dev/works-offline
+               Current page does not respond with a 200 when offline
+               https://web.dev/works-offline
 
                 expected: >=[32m1[0m
                    found: [31m0[0m
@@ -391,11 +391,11 @@ describe('Lighthouse CI CLI', () => {
       expect(stderr).toMatchInlineSnapshot(`
         "Checking assertions against 1 URL(s), 2 total run(s)
 
-        2 result(s) for [1mhttp://localhost:XXXX/app/[0m
+        2 result(s) for [1mhttp://localhost:XXXX/app/[0m :
 
           [31mX[0m  [1mfirst-contentful-paint[0m failure for [1mmaxNumericValue[0m assertion
-             First Contentful Paint
-             Documentation: https://web.dev/first-contentful-paint
+               First Contentful Paint
+               https://web.dev/first-contentful-paint
 
                 expected: <=[32m1[0m
                    found: [31mXXXX[0m
@@ -403,8 +403,8 @@ describe('Lighthouse CI CLI', () => {
 
 
           [31mX[0m  [1mperformance-budget[0m.script.size failure for [1mmaxNumericValue[0m assertion
-             Performance budget
-             Documentation: https://developers.google.com/web/tools/lighthouse/audits/budgets
+               Performance budget
+               https://developers.google.com/web/tools/lighthouse/audits/budgets
 
                 expected: <=[32mXXXX[0m
                    found: [31mXXXX[0m
@@ -423,11 +423,11 @@ describe('Lighthouse CI CLI', () => {
       expect(stderr).toMatchInlineSnapshot(`
         "Checking assertions against 1 URL(s), 2 total run(s)
 
-        1 result(s) for [1mhttp://localhost:XXXX/app/[0m
+        1 result(s) for [1mhttp://localhost:XXXX/app/[0m :
 
           [31mX[0m  [1mresource-summary[0m.script.size failure for [1mmaxNumericValue[0m assertion
-             Keep request counts low and transfer sizes small
-             Documentation: https://developers.google.com/web/tools/lighthouse/audits/budgets
+               Keep request counts low and transfer sizes small
+               https://developers.google.com/web/tools/lighthouse/audits/budgets
 
                 expected: <=[32mXXXX[0m
                    found: [31mXXXX[0m


### PR DESCRIPTION
The motivation is that when I had multiple URLs' results in the assertion dump...  I had a hard time figuring out if the "  16 result(s) for <url>" text was summarizing all the stuff above it, or providing a header of the stuff below it.

so i added a colon.

Also, I think formatting-wise it's a little clearer to indent the audittitle/docs. And i think we dont need the "documentation: " label.

---------

running the unit tests didnt really work for me.

I got a couple of these: 
![image](https://user-images.githubusercontent.com/39191/78947378-04011500-7a7a-11ea-84a7-97654b3d7b85.png)

and then many of the tests that were affected by these text changes werent run. i never saw failures. (i updated the snapshots by hand! 😨 )

i saw some other things too that I couldn't explain, but ... i'll leave it there for now. 

🤞 that the CI's tests run this with no problem! :)