### PR TITLE
feat(cli): add user-timing assertion support

### DIFF
--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -107,6 +107,8 @@ Your custom user timings using [`performance.mark`](https://developer.mozilla.or
 
 The general format for asserting against a user timing value is `"user-timings:<kebab-cased-name>": ["<level>", {maxNumericValue: <value in milliseconds>}]`. For example, if you wanted to assert that a mark with name `My Custom Mark` started within the first 2s of page load and that a measure `my:custom-@-Measure` lasted fewer than 50 ms you would use the following assertions config.
 
+Note that only the first matching entry with the name will be used from each run and the rest will be ignored.
+
 ```json
 {
   "assertions": {

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -101,6 +101,21 @@ The below example warns when FCP is above 2 seconds on _all_ pages and warns whe
 }
 ```
 
+### User Timings
+
+Your custom user timings using [`performance.mark`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) and [`performance.measure`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure) can be asserted against as well.
+
+The general format for asserting against a user timing value is `"user-timings:<kebab-cased-name>": ["<level>", {maxNumericValue: <value in milliseconds>}]`. For example, if you wanted to assert that a mark with name `My Custom Mark` started within the first 2s of page load and that a measure `my:custom-@-Measure` lasted fewer than 50 ms you would use the following assertions config.
+
+```json
+{
+  "assertions": {
+    "user-timings:my-custom-mark": ["warn", {"maxNumericValue": 2000}],
+    "user-timings:my-custom-measure": ["error", {"maxNumericValue": 50}]
+  }
+}
+```
+
 ## Presets
 
 There are three presets available to provide a good starting point. Presets can be extended with manual assertions.

--- a/packages/utils/src/lodash.js
+++ b/packages/utils/src/lodash.js
@@ -44,9 +44,17 @@ function merge(v1, v2) {
 /**
  * Converts a string from camelCase to kebab-case.
  * @param {string} s
+ * @param {{alphanumericOnly?: boolean}} [opts]
  */
-function kebabCase(s) {
-  return s.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+function kebabCase(s, opts) {
+  let kebabed = s.replace(/([a-z])([A-Z])/g, '$1-$2');
+  if (opts && opts.alphanumericOnly) {
+    kebabed = kebabed
+      .replace(/[^a-z0-9]+/gi, '-')
+      .replace(/-+/g, '-')
+      .replace(/(^-|-$)/g, '');
+  }
+  return kebabed.toLowerCase();
 }
 
 /**

--- a/packages/utils/test/lodash.test.js
+++ b/packages/utils/test/lodash.test.js
@@ -135,11 +135,30 @@ describe('lodash.js', () => {
       // WAI
       expect(_.kebabCase('camelCase')).toEqual('camel-case');
       expect(_.kebabCase('kebab-case')).toEqual('kebab-case');
+      expect(_.kebabCase('exampleURL')).toEqual('example-url');
 
       // Not implemented but should probably work consistently at some point.
       // Tests just for documentation.
+      expect(_.kebabCase('kebab-case:document.type')).toEqual('kebab-case:document.type');
+      expect(_.kebabCase('mixed-Case3_Issues+')).toEqual('mixed-case3_issues+');
       expect(_.kebabCase('ALL CAPS')).toEqual('all caps');
       expect(_.kebabCase('snake_case')).toEqual('snake_case');
+    });
+
+    it('should convert strings to kebab-case alphanumericOnly', () => {
+      // WAI
+      expect(_.kebabCase('camelCase', {alphanumericOnly: true})).toEqual('camel-case');
+      expect(_.kebabCase('kebab-case', {alphanumericOnly: true})).toEqual('kebab-case');
+      expect(_.kebabCase('kebab-case:document.type', {alphanumericOnly: true})).toEqual(
+        'kebab-case-document-type'
+      );
+      expect(_.kebabCase('exampleURL', {alphanumericOnly: true})).toEqual('example-url');
+      expect(_.kebabCase('!exampleURL', {alphanumericOnly: true})).toEqual('example-url');
+      expect(_.kebabCase('mixed-Case3_Issues+', {alphanumericOnly: true})).toEqual(
+        'mixed-case3-issues'
+      );
+      expect(_.kebabCase('ALL CAPS', {alphanumericOnly: true})).toEqual('all-caps');
+      expect(_.kebabCase('snake_case', {alphanumericOnly: true})).toEqual('snake-case');
     });
   });
 


### PR DESCRIPTION
closes #279 

how does this API feel @WebCloud ?


### User Timings

The general format for asserting against a user timing value is `"user-timings:<kebab-cased-name>": ["<level>", {maxNumericValue: <value in milliseconds>}]`. For example, if you wanted to assert that a mark with name `My Custom Mark` started within the first 2s of page load and that a measure `my:custom-@-Measure` lasted fewer than 50 ms you would use the following assertions config.

Note that only the first matching entry with the name will be used from each run and the rest will be ignored.

```json
{
  "assertions": {
    "user-timings:my-custom-mark": ["warn", {"maxNumericValue": 2000}],
    "user-timings:my-custom-measure": ["error", {"maxNumericValue": 50}]
  }
}
```