### PR TITLE
fix(cli): clear HTML reports on collect

### DIFF
--- a/packages/cli/src/collect/collect.js
+++ b/packages/cli/src/collect/collect.js
@@ -11,7 +11,7 @@ const {determineChromePath} = require('../utils.js');
 const FallbackServer = require('./fallback-server.js');
 const LighthouseRunner = require('./lighthouse-runner.js');
 const PuppeteerManager = require('./puppeteer-manager.js');
-const {saveLHR, clearSavedLHRs} = require('@lhci/utils/src/saved-reports.js');
+const {saveLHR, clearSavedReportsAndLHRs} = require('@lhci/utils/src/saved-reports.js');
 const {
   runCommandAndWaitForPattern,
   killProcessTree,
@@ -178,7 +178,7 @@ function checkIgnoredChromeFlagsOption(options) {
  */
 async function runCommand(options) {
   if (options.method !== 'node') throw new Error(`Method "${options.method}" not yet supported`);
-  if (!options.additive) clearSavedLHRs();
+  if (!options.additive) clearSavedReportsAndLHRs();
 
   checkIgnoredChromeFlagsOption(options);
 

--- a/packages/utils/src/saved-reports.js
+++ b/packages/utils/src/saved-reports.js
@@ -9,6 +9,7 @@ const fs = require('fs');
 const path = require('path');
 const LHCI_DIR = path.join(process.cwd(), '.lighthouseci');
 const LHR_REGEX = /^lhr-\d+\.json$/;
+const LH_HTML_REPORT_REGEX = /^lhr-\d+\.html$/;
 const ASSERTION_RESULTS_PATH = path.join(LHCI_DIR, 'assertion-results.json');
 const URL_LINK_MAP_PATH = path.join(LHCI_DIR, 'links.json');
 
@@ -55,10 +56,10 @@ function getHTMLReportForLHR(lhr) {
   return ReportGenerator.generateReportHtml(lhr);
 }
 
-function clearSavedLHRs() {
+function clearSavedReportsAndLHRs() {
   ensureDirectoryExists();
   for (const file of fs.readdirSync(LHCI_DIR)) {
-    if (!LHR_REGEX.test(file)) continue;
+    if (!LHR_REGEX.test(file) && !LH_HTML_REPORT_REGEX.test(file)) continue;
 
     const filePath = path.join(LHCI_DIR, file);
     fs.unlinkSync(filePath);
@@ -119,7 +120,7 @@ module.exports = {
   getHTMLReportForLHR,
   loadSavedLHRs,
   saveLHR,
-  clearSavedLHRs,
+  clearSavedReportsAndLHRs,
   loadAssertionResults,
   saveAssertionResults,
   getSavedReportsDirectory,


### PR DESCRIPTION
ref #119 

DO NOT MERGE INTO MASTER, I'll be putting up a `next` branch to collect our breaking changes in case we need to publish fixes on 0.3.x in the meantime


BREAKING CHANGE: HTML reports in .lighthouseci/ will also be deleted on running of `collect`, not just the JSON