### PR TITLE
docs(README): fix screenshot url

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -4,8 +4,7 @@
 
 The LHCI server saves historical Lighthouse data, displays trends in a dashboard, and offers an in-depth build comparison UI to uncover differences between builds.
 
-<img src="https://user-images.githubusercontent.com/2301202/79480502-c8af9a80-7fd3-11ea-8087-52f6c8ba6f03.png
-"
+<img src="https://user-images.githubusercontent.com/2301202/79480502-c8af9a80-7fd3-11ea-8087-52f6c8ba6f03.png"
 alt="Screenshot of the Lighthouse CI server dashboard UI" width="48%"> <img src="https://user-images.githubusercontent.com/2301202/70814650-85c58800-1d91-11ea-925e-af9d03f1b20d.png"
 alt="Screenshot of the Lighthouse CI server diff UI" width="48%">
 


### PR DESCRIPTION
Fixes the image url for one of the screenshots in the LHCI server readme file.