### PR TITLE
docs(getting-started): larger link text

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -180,7 +180,7 @@ The setup so far will automatically assert the Lighthouse team's recommended set
 
 ## Configuration
 
-Lighthouse CI uses a `lighthouserc.json` file to configure all the core commands used. You can replace the options on the command-line we've seen so far with the following configuration file. Read more about how to configure Lighthouse CI [in our docs](./configuration.md).
+Lighthouse CI uses a `lighthouserc.json` file to configure all the core commands used. You can replace the options on the command-line we've seen so far with the following configuration file. Read more about [how to configure Lighthouse CI](./configuration.md).
 
 ```bash
 # no need to pass explicit options


### PR DESCRIPTION
super important link and on my screen there's a wordwrap AND it is just small.

![image](https://user-images.githubusercontent.com/39191/80743329-a2105a00-8ad1-11ea-8025-c0b824a73ded.png)



but its so important.

