### PR TITLE
docs(getting-started): use checkout@v2

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,7 +55,7 @@ jobs:
     name: Lighthouse CI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js 10.x
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
I noticed this myself but then someone called it out and mentioned a nasty bug folks hit
https://github.com/paulirish/lite-youtube-embed/pull/55#discussion_r418314006
