### PR TITLE
feat(cli): add filesystem upload target

### DIFF
--- a/packages/cli/src/cli.js
+++ b/packages/cli/src/cli.js
@@ -46,6 +46,7 @@ async function run() {
     .help('help')
     .version(pkg.version)
     .usage('lhci <command> <options>')
+    .wrap(yargs.terminalWidth())
     .env('LHCI')
     .demand(1)
     .command('collect', 'Run Lighthouse and save the results to a local folder', commandYargs =>

--- a/packages/cli/test/collect-puppeteer.test.js
+++ b/packages/cli/test/collect-puppeteer.test.js
@@ -60,9 +60,9 @@ describe('Lighthouse CI collect CLI with puppeteer', () => {
     const chromePathHelp = stdout.match(/--chromePath.*\n.*\n.*/);
     expect(chromePathHelp).toMatchInlineSnapshot(`
       Array [
-        "--chromePath               The path to the Chrome or Chromium executable to
-                                   use for collection.
-        --puppeteerScript          The path to a script that manipulates the browser",
+        "--chromePath               The path to the Chrome or Chromium executable to use for collection.
+        --puppeteerScript          The path to a script that manipulates the browser with puppeteer before running Lighthouse, used for auth.
+        --puppeteerLaunchOptions   The object of puppeteer launch options",
       ]
     `);
     expect(stderr).toMatchInlineSnapshot(`""`);

--- a/packages/utils/src/lodash.js
+++ b/packages/utils/src/lodash.js
@@ -252,6 +252,14 @@ module.exports = {
     return this.maxBy(items, o => -keyFn(o));
   },
   /**
+   * @template TArr
+   * @param {Array<TArr>} items
+   * @param {(o: TArr) => number} keyFn
+   */
+  sortBy(items, keyFn) {
+    return items.slice().sort((a, b) => keyFn(a) - keyFn(b));
+  },
+  /**
    * @template T
    * @param {T} object
    * @param {Array<keyof T>} propertiesToPick

--- a/types/upload.d.ts
+++ b/types/upload.d.ts
@@ -7,21 +7,43 @@
 declare global {
   namespace LHCI {
     namespace UploadCommand {
-      export type UploadTarget = 'lhci' | 'temporary-public-storage';
+      export type UploadTarget = 'lhci' | 'temporary-public-storage' | 'filesystem';
 
       export interface Options {
         target: UploadTarget;
-        token?: string;
-        ignoreDuplicateBuildFailure?: boolean;
+        /** Temporary public storage only */
         uploadUrlMap?: boolean;
+        /** LHCI only */
+        token?: string;
+        serverBaseUrl: string;
+        ignoreDuplicateBuildFailure?: boolean;
         basicAuth?: ServerCommand.Options['basicAuth'];
         extraHeaders?: Record<string, string>;
+        /** Filesystem only */
+        outputDir?: string;
+        reportFilenamePattern: string;
+        /** Applies to multiple targets */
         githubToken?: string;
         githubApiHost?: string;
         githubAppToken?: string;
         githubStatusContextSuffix?: string;
-        serverBaseUrl: string;
         urlReplacementPatterns: string[];
+      }
+
+      export interface ManifestEntrySummary {
+        performance: number; // all category scores on 0-1 scale
+        accessibility: number;
+        'best-practices': number;
+        seo: number;
+        pwa: number;
+      }
+
+      export interface ManifestEntry {
+        url: string; // finalUrl of the run
+        isRepresentativeRun: boolean; // whether it was the median run for the URL
+        jsonPath: string;
+        htmlPath: string;
+        summary: EntrySummary;
       }
     }
   }


### PR DESCRIPTION
closes #142 

Basic usage: `lhci upload --target=filesystem --outputDir=./the-reports`

```
|- (cwd)
  |- the-reports
    |- manifest.json
    |- www_example_com-_page-2020_05_22_21_15_05.report.json
    |- www_example_com-_page-2020_05_22_21_15_05.report.html
```

```jsonc
[
  {
    "url": "https://www.example.com/page",
    "isRepresentativeRun": true, // whether it's the median run
    "htmlPath": "/path/to/cwd/the-reports/www_example_com-_page-2020_05_22_21_15_05.report.html",
    "jsonPath": "/path/to/cwd/the-reports/www_example_com-_page-2020_05_22_21_15_05.report.json",
    "summary": {"performance": 0.95, "seo": 0.9, "best-practices": 1}
  }
]
```
