### PR TITLE
fix(cli): throw on existing manifest.json

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -417,7 +417,7 @@ The target location to which Lighthouse CI should upload the reports.
 
 - You want to process the raw Lighthouse results yourself locally.
 - You want access to the report files on the local filesystem.
-- You don't want to upload the results to a custom location that isn't supported by Lighthouse CI.
+- You want to upload the results to a custom location that isn't supported by Lighthouse CI.
 
 #### `token`
 
@@ -516,7 +516,7 @@ For example, by default Lighthouse CI will automatically replace the port of tes
 
 _target=filesystem only_
 
-The directory relative to the current working directory in which to output a `manifest.json` along with the Lighthouse reports collected. Any existing `manifest.json` in that directory will be overwritten.
+The directory relative to the current working directory in which to output a `manifest.json` along with the Lighthouse reports collected. If `manifest.json` already exists in that directory, the action will fail.
 
 Sample file structure for `--outputDir=./lhci` on `https://www.example.com/page`
 

--- a/packages/cli/src/upload/upload.js
+++ b/packages/cli/src/upload/upload.js
@@ -511,7 +511,11 @@ async function runFilesystemTarget(options) {
   const representativeLhrs = computeRepresentativeRuns(lhrsByUrl);
 
   const targetDir = path.resolve(process.cwd(), options.outputDir || '');
+  const manifestPath = path.join(targetDir, 'manifest.json');
   if (!fs.existsSync(targetDir)) fs.mkdirSync(targetDir, {recursive: true});
+  if (fs.existsSync(manifestPath)) {
+    throw new Error('manifest.json already exists in outputDir, choose another location');
+  }
 
   print(`Dumping ${lhrs.length} reports to disk at ${targetDir}...\n`);
   /** @type {Array<LHCI.UploadCommand.ManifestEntry>} */
@@ -554,7 +558,6 @@ async function runFilesystemTarget(options) {
     manifest.push(entry);
   }
 
-  const manifestPath = path.join(targetDir, 'manifest.json');
   fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
   print('Done writing reports to disk.\n');
 }


### PR DESCRIPTION
followup to #328 and #142 

prevents accidental overwriting and misconceptions about merging manifest.json files when using target=filesystem