### PR TITLE
Trim down Dockerfile

### DIFF
--- a/docs/recipes/docker-server/Dockerfile
+++ b/docs/recipes/docker-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:12-buster-slim
 
 WORKDIR /usr/src/lhci
 COPY package.json .


### PR DESCRIPTION
We noticed that the image size could be greatly reduced by using
a smaller base image. This migrates the base image to `node:12-buster-slim`,
which provides the same functionality but shrinks the image size from
1.04GB to 286MB.

This also updates to the latest Node version 12.