### PR TITLE
Trim down Dockerfile

### DIFF
--- a/docs/recipes/docker-client/Dockerfile
+++ b/docs/recipes/docker-client/Dockerfile
@@ -1,13 +1,14 @@
-FROM node:10
+FROM node:12-buster-slim
 
 # Install utilities
-RUN apt-get update --fix-missing && apt-get -y upgrade
+RUN apt-get update --fix-missing && apt-get -y upgrade && apt-get install -y wget gnupg && apt-get clean
 
 # Install latest chrome stable package.
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-RUN apt-get update
-RUN apt-get install -y google-chrome-stable --no-install-recommends
+RUN apt-get update \
+    && apt-get install -y google-chrome-stable --no-install-recommends \
+    && apt-get clean
 
 # Install Lighthouse CI
 RUN npm install -g @lhci/cli@0.4.0


### PR DESCRIPTION
We noticed that the image size could be greatly reduced by using
a smaller base image. This migrates the base image to node:12-buster-slim,
which provides the same functionality but shrinks the image size from
1.5GB to 720MB.
Also, the apt-cache gets cleaned up after package installation to avoid keeping
it in a layer of the Docker image.

This also updates the image to the latest Node version 12.

See also #331 for the server image.