### PR TITLE
Add info tip to category score popup

### DIFF
--- a/packages/server/src/ui/routes/project-dashboard/graphs/category-score/category-score-graph.css
+++ b/packages/server/src/ui/routes/project-dashboard/graphs/category-score/category-score-graph.css
@@ -152,3 +152,23 @@
   font-size: var(--base-font-size);
   margin-right: calc(var(--base-spacing) / 2);
 }
+
+.category-score-graph__info-tip {
+  padding: 0 var(--base-spacing);
+  margin-bottom: var(--base-spacing);
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  color: var(--neutral-color);
+  text-align: center;
+  line-height: var(--base-font-size);
+  font-size: var(--subtext-font-size);
+  font-weight: var(--medium-font-weight);
+}
+
+.category-score-graph__info-tip .material-icons {
+  font-size: var(--base-font-size);
+  margin-right: calc(var(--base-spacing) / 2);
+}

--- a/packages/server/src/ui/routes/project-dashboard/graphs/category-score/category-score-graph.jsx
+++ b/packages/server/src/ui/routes/project-dashboard/graphs/category-score/category-score-graph.jsx
@@ -36,9 +36,17 @@ const VersionChangeWarning = () => {
   );
 };
 
-/** @param {{selectedBuildId: string|undefined, medianStatistics: Array<StatisticWithBuild>, versionChanges: Array<{build: LHCI.ServerCommand.Build}>, pinned: boolean}} props */
+const InfoTip = () => {
+  return (
+    <div className="category-score-graph__version-change-warning">
+      <i className="material-icons">info</i> Click to pin
+    </div>
+  );
+};
+
+/** @param {{selectedBuildId: string|undefined, medianStatistics: Array<StatisticWithBuild>, versionChanges: Array<{build: LHCI.ServerCommand.Build}>, pinned: boolean, hideInfoTip: boolean}} props */
 const HoverCardWithDiff = props => {
-  const {selectedBuildId, medianStatistics: stats} = props;
+  const {selectedBuildId, medianStatistics: stats, hideInfoTip} = props;
   const statIndex = selectedBuildId ? stats.findIndex(s => s.buildId === selectedBuildId) : -1;
   const stat = statIndex !== -1 ? stats[statIndex] : undefined;
 
@@ -56,6 +64,7 @@ const HoverCardWithDiff = props => {
     children = (
       <Fragment>
         {versionChange ? <VersionChangeWarning /> : null}
+        {hideInfoTip ? null : <InfoTip />}
         <Gauge score={stat.value} diff={diff} />
         {diff ? <ScoreDeltaBadge diff={diff} /> : null}
       </Fragment>

--- a/packages/server/src/ui/routes/project-dashboard/graphs/category-score/category-score-graph.jsx
+++ b/packages/server/src/ui/routes/project-dashboard/graphs/category-score/category-score-graph.jsx
@@ -64,7 +64,7 @@ const HoverCardWithDiff = props => {
     children = (
       <Fragment>
         {versionChange ? <VersionChangeWarning /> : null}
-        {hideInfoTip ? null : <InfoTip />}
+        {hideInfoTip || props.pinned ? null : <InfoTip />}
         <Gauge score={stat.value} diff={diff} />
         {diff ? <ScoreDeltaBadge diff={diff} /> : null}
       </Fragment>

--- a/packages/server/src/ui/routes/project-dashboard/graphs/category-score/category-score-graph.jsx
+++ b/packages/server/src/ui/routes/project-dashboard/graphs/category-score/category-score-graph.jsx
@@ -39,7 +39,7 @@ const VersionChangeWarning = () => {
 const InfoTip = () => {
   return (
     <div className="category-score-graph__version-change-warning">
-      <i className="material-icons">info</i> Click to pin
+      <i className="material-icons">info</i> Click graph to pin
     </div>
   );
 };

--- a/packages/server/src/ui/routes/project-dashboard/graphs/category-score/category-score-graph.jsx
+++ b/packages/server/src/ui/routes/project-dashboard/graphs/category-score/category-score-graph.jsx
@@ -38,7 +38,7 @@ const VersionChangeWarning = () => {
 
 const InfoTip = () => {
   return (
-    <div className="category-score-graph__version-change-warning">
+    <div className="category-score-graph__info-tip">
       <i className="material-icons">info</i> Click graph to pin
     </div>
   );

--- a/packages/server/src/ui/routes/project-dashboard/graphs/category-score/category-score-graph.jsx
+++ b/packages/server/src/ui/routes/project-dashboard/graphs/category-score/category-score-graph.jsx
@@ -44,7 +44,7 @@ const InfoTip = () => {
   );
 };
 
-/** @param {{selectedBuildId: string|undefined, medianStatistics: Array<StatisticWithBuild>, versionChanges: Array<{build: LHCI.ServerCommand.Build}>, pinned: boolean, hideInfoTip: boolean}} props */
+/** @param {{selectedBuildId: string|undefined, medianStatistics: Array<StatisticWithBuild>, versionChanges: Array<{build: LHCI.ServerCommand.Build}>, pinned: boolean, hideInfoTip?: boolean}} props */
 const HoverCardWithDiff = props => {
   const {selectedBuildId, medianStatistics: stats, hideInfoTip} = props;
   const statIndex = selectedBuildId ? stats.findIndex(s => s.buildId === selectedBuildId) : -1;


### PR DESCRIPTION
Fixes #357

Make it clearer that you MUST click on the graph dot for the popup to be "pinned" or "suspended" for further action (ie clicking "Report").

<img width="1661" alt="Screen Shot 2020-06-26 at 12 10 46 PM" src="https://user-images.githubusercontent.com/6808172/85883890-5b746e80-b7a7-11ea-890c-9004e9351ca4.png">
