### PR TITLE
fix(utils): better error message for git failures

### DIFF
--- a/docs/recipes/docker-client/Dockerfile
+++ b/docs/recipes/docker-client/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:12-buster-slim
 
 # Install utilities
-RUN apt-get update --fix-missing && apt-get -y upgrade && apt-get install -y wget gnupg && apt-get clean
+RUN apt-get update --fix-missing && apt-get -y upgrade && apt-get install -y git wget gnupg && apt-get clean
 
 # Install latest chrome stable package.
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -

--- a/packages/cli/src/upload/upload.js
+++ b/packages/cli/src/upload/upload.js
@@ -30,6 +30,7 @@ const {
   getAncestorHashForBase,
   getAncestorHashForBranch,
   getGitHubRepoSlug,
+  getCurrentBranchSafe,
 } = require('@lhci/utils/src/build-context.js');
 
 /** @param {string} message */
@@ -108,7 +109,7 @@ function buildCommand(yargs) {
       type: 'boolean',
       description:
         '[temporary-public-storage only] Whether to post links to historical base results to storage or not. Defaults to true only on master branch.',
-      default: getCurrentBranch() === 'master',
+      default: getCurrentBranchSafe() === 'master',
     },
     urlReplacementPatterns: {
       type: 'array',

--- a/packages/utils/src/build-context.js
+++ b/packages/utils/src/build-context.js
@@ -130,8 +130,8 @@ function getCurrentBranchRaw_() {
     encoding: 'utf8',
   });
 
-  const branch = result.stdout.trim();
-  if (result.status !== 0 || branch === 'HEAD') {
+  const branch = typeof result.stdout === 'string' && result.stdout.trim();
+  if (result.status !== 0 || !branch || branch === 'HEAD') {
     throw new Error(
       'Unable to determine current branch with `git rev-parse --abbrev-ref HEAD`. ' +
         'This can be overridden with setting LHCI_BUILD_CONTEXT__CURRENT_BRANCH env.'
@@ -142,12 +142,25 @@ function getCurrentBranchRaw_() {
 }
 
 /**
+ * Returns the current branch name. Throws if it could not be determined.
  * @return {string}
  */
 function getCurrentBranch() {
   const branch = getCurrentBranchRaw_();
   if (branch === 'HEAD') throw new Error('Unable to determine current branch');
   return branch.replace('refs/heads/', '').slice(0, 40);
+}
+
+/**
+ * Returns the current branch name. Returns `undefined` if it could not be determined.
+ * @return {string|undefined}
+ */
+function getCurrentBranchSafe() {
+  try {
+    return getCurrentBranch();
+  } catch (err) {
+    return undefined;
+  }
 }
 
 /**
@@ -335,6 +348,7 @@ module.exports = {
   getCurrentHash,
   getCommitTime,
   getCurrentBranch,
+  getCurrentBranchSafe,
   getExternalBuildUrl,
   getCommitMessage,
   getAuthor,


### PR DESCRIPTION
fixes #370 , typescript believes this to be an impossibility and ~~I'm also not sure how to reproduce it either~~ It's only reproducible when git is not installed, so no tests, but seems like a reasonable safeguard to have