### PR TITLE
feat(server): support socket path in server config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1205,6 +1205,26 @@ module.exports = {
 }
 ```
 
+### Socket Path for Database Connection
+
+```json
+{
+  "ci": {
+    "server": {
+      "storage": {
+        "sqlDialect": "mysql",
+        "sqlSocketPath": "/var/lib/mysql/mysql.sock",
+        "sequelizeOptions": {
+          "database": "reports",
+          "username": "admin",
+          "password": "password"
+        }
+      }
+    }
+  }
+}
+```
+
 ### Custom SSL Certificate for Database Connection
 
 ```js

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -892,15 +892,6 @@ _sqlDialect=sqlite only_
 
 The path to the sqlite database on the local filesystem relative to the current working directory.
 
-##### `storage.sqlSocketPath`
-
-_sqlDialect=mysql or sqlDialect=postgres only_
-
-The database Unix socket file path for the MySQL or PostgreSQL database.
-
-Note: If used, this option will require to specify the `database`, `username` and `password` sequelize options.
-See `storage.sequelizeOptions` for more information.
-
 ##### `storage.sqlConnectionUrl`
 
 _sqlDialect=mysql or sqlDialect=postgres only_
@@ -1213,7 +1204,9 @@ module.exports = {
     "server": {
       "storage": {
         "sqlDialect": "mysql",
-        "sqlSocketPath": "/var/lib/mysql/mysql.sock",
+        "sqlDialectOptions": {
+          "socketPath": "/var/lib/mysql/mysql.sock"
+        },
         "sequelizeOptions": {
           "database": "reports",
           "username": "admin",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -306,7 +306,7 @@ module.exports = async (browser, context) => {
   await page.click('[type="submit"]');
   await page.waitForNavigation();
   // close session for next run
-  await page.close()
+  await page.close();
 };
 ```
 
@@ -891,6 +891,15 @@ One of `mysql`, `postgres`, or `sqlite`. `sqlite` in a local file on disk has be
 _sqlDialect=sqlite only_
 
 The path to the sqlite database on the local filesystem relative to the current working directory.
+
+##### `storage.sqlSocketPath`
+
+_sqlDialect=mysql or sqlDialect=postgres only_
+
+The database Unix socket file path for the MySQL or PostgreSQL database.
+
+Note: If used, this option will require to specify the `database`, `username` and `password` sequelize options.
+See `storage.sequelizeOptions` for more information.
 
 ##### `storage.sqlConnectionUrl`
 

--- a/packages/server/src/api/storage/sql/sql.js
+++ b/packages/server/src/api/storage/sql/sql.js
@@ -92,6 +92,32 @@ function createSequelize(options) {
     });
   }
 
+  if (options.sqlSocketPath) {
+    if (
+      !options.sequelizeOptions ||
+      !options.sequelizeOptions.database ||
+      !options.sequelizeOptions.username ||
+      !options.sequelizeOptions.password
+    ) {
+      throw new Error(
+        `Cannot use ${dialect} with socketPath without database, username, or password`
+      );
+    }
+
+    return new Sequelize(
+      options.sequelizeOptions.database,
+      options.sequelizeOptions.username,
+      options.sequelizeOptions.password,
+      {
+        ...sequelizeOptions,
+        dialect: options.sqlDialect,
+        host: options.sqlSocketPath,
+        ssl: !!options.sqlConnectionSsl,
+        dialectOptions: options.sqlDialectOptions,
+      }
+    );
+  }
+
   if (!options.sqlConnectionUrl) throw new Error(`Cannot use ${dialect} without a database URL`);
 
   return new Sequelize(options.sqlConnectionUrl, {

--- a/packages/server/src/api/storage/sql/sql.js
+++ b/packages/server/src/api/storage/sql/sql.js
@@ -92,7 +92,7 @@ function createSequelize(options) {
     });
   }
 
-  if (options.sqlSocketPath) {
+  if (options.sqlDialectOptions && options.sqlDialectOptions.socketPath) {
     if (
       !options.sequelizeOptions ||
       !options.sequelizeOptions.database ||
@@ -111,7 +111,6 @@ function createSequelize(options) {
       {
         ...sequelizeOptions,
         dialect: options.sqlDialect,
-        host: options.sqlSocketPath,
         ssl: !!options.sqlConnectionSsl,
         dialectOptions: options.sqlDialectOptions,
       }

--- a/packages/server/test/mysql-socket-path-server.test.js
+++ b/packages/server/test/mysql-socket-path-server.test.js
@@ -1,0 +1,52 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+const runTests = require('./server-test-suite.js').runTests;
+const runServer = require('../src/server.js').createServer;
+
+describe('mysql server (socket path)', () => {
+  if (!process.env.MYSQL_SOCKET_PATH) {
+    it.skip('should work on mysql', () => {});
+    return;
+  }
+
+  const state = {
+    port: undefined,
+    closeServer: undefined,
+  };
+
+  beforeAll(async () => {
+    const {port, close, storageMethod} = await runServer({
+      logLevel: 'silent',
+      port: 0,
+      storage: {
+        storageMethod: 'sql',
+        sqlDialect: 'mysql',
+        sqlDialectOptions: {
+          socketPath: process.env.MYSQL_SOCKET_PATH,
+        },
+        sequelizeOptions: {
+          database: 'lighthouse_ci_test',
+          username: 'root',
+          password: 'mysql',
+        },
+      },
+    });
+
+    state.port = port;
+    state.closeServer = close;
+    state.storageMethod = storageMethod;
+  });
+
+  afterAll(() => {
+    state.closeServer();
+  });
+
+  runTests(state);
+});

--- a/packages/server/test/postgres-socket-path-server.test.js
+++ b/packages/server/test/postgres-socket-path-server.test.js
@@ -1,0 +1,52 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+const runTests = require('./server-test-suite.js').runTests;
+const runServer = require('../src/server.js').createServer;
+
+describe('postgres server', () => {
+  if (!process.env.POSTGRES_SOCKET_PATH) {
+    it.skip('should work on postgres', () => {});
+    return;
+  }
+
+  const state = {
+    port: undefined,
+    closeServer: undefined,
+  };
+
+  beforeAll(async () => {
+    const {port, close, storageMethod} = await runServer({
+      logLevel: 'silent',
+      port: 0,
+      storage: {
+        storageMethod: 'sql',
+        sqlDialect: 'postgres',
+        sqlDialectOptions: {
+          socketPath: process.env.POSTGRES_SOCKET_PATH,
+        },
+        sequelizeOptions: {
+          database: 'lighthouse_ci_test',
+          username: 'postgres',
+          password: 'postgres',
+        },
+      },
+    });
+
+    state.port = port;
+    state.closeServer = close;
+    state.storageMethod = storageMethod;
+  });
+
+  afterAll(() => {
+    state.closeServer();
+  });
+
+  runTests(state);
+});

--- a/types/server.d.ts
+++ b/types/server.d.ts
@@ -170,6 +170,7 @@ declare global {
         sqlDatabasePath?: string;
         sqlConnectionSsl?: string;
         sqlConnectionUrl?: string;
+        sqlSocketPath?: string;
         sqlDangerouslyResetDatabase?: boolean;
         sequelizeOptions?: import('sequelize').Options;
       }

--- a/types/server.d.ts
+++ b/types/server.d.ts
@@ -161,6 +161,7 @@ declare global {
         storageMethod: 'sql' | 'spanner';
         sqlDialect: 'sqlite' | 'mysql' | 'postgres';
         sqlDialectOptions?: {
+          socketPath?: string;
           ssl?: {
             ca?: string;
             key?: string;
@@ -170,7 +171,6 @@ declare global {
         sqlDatabasePath?: string;
         sqlConnectionSsl?: string;
         sqlConnectionUrl?: string;
-        sqlSocketPath?: string;
         sqlDangerouslyResetDatabase?: boolean;
         sequelizeOptions?: import('sequelize').Options;
       }


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/lighthouse-ci/issues/385

- [x] Add `sqlSocketPath` option support in the config
- [x] Validate config UX with project maintainers
- [x] Add tests for new socket path option in config (Looking for guidance here 😄 )
- [x] Mention `sqlSocketPath` in `docs/configuration.md`

As mentioned in the ticket, my team and I were looking to set up lighthouse-ci server on Google Cloud Run (serverless containers) with a Google Cloud SQL database (Postgres) and our only possibility to link the two was to use a socket path instead of a connection URL.

Let me know what you think of this config, there's probably a few things that still need to be done or validated in terms of how you want the config to look like.
Also @patrickhulce mentioned that testing might be quite hard for this one, so I'm looking for any proposal on how I could tackle this 😄 
