### PR TITLE
Add config for Next.js

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -171,6 +171,7 @@ Autorun will attempt to automatically detect the directory of your static site f
 
 - `dist` (default name for vue-cli, parcel, and webpack)
 - `build` (default name for create-react-app and preact-cli)
+- `out` (default name for Next.js, note this will only be generated with `next export`)
 - `public` (default name for gatsby)
 
 If your productionized static assets live in a different folder, you'd like to run Lighthouse CI on a specific subset of your static pages, your project does not use a build step at all or a different server, see the [`lhci collect` documentation](#collect) for how to configure your project.

--- a/packages/cli/src/autorun/autorun.js
+++ b/packages/cli/src/autorun/autorun.js
@@ -25,6 +25,9 @@ const BUILD_DIR_PRIORITY = [
   // likely a built version of the site
   // default name for create-react-app and preact-cli
   'build',
+  // likely a built version of the site
+  // default name for next.js
+  'out',
   // riskier, sometimes is a built version of the site but also can be just a dir of static assets
   // default name for gatsby
   'public',


### PR DESCRIPTION
By default, Next.js builds to the folder `out` when the command `next export` is used. I can't think of an alternate use for the out directory beyond builds, so I think it would be useful if this is one of the defaults.