### PR TITLE
Update "target" configuration documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -404,9 +404,8 @@ Saves the runs in the `.lighthouseci/` folder to desired target and sets a GitHu
 ```bash
 Options:
   --target                       The type of target to upload the data to. If set to anything other
-                                 than "lhci", some of the options will not apply.          [string]
-                                 [choices: "lhci", "temporary-public-storage", "filesytem"]
-                                 [default: "lhci"]
+                                 than "lhci", some of the options will not apply.
+               [string] [choices: "lhci", "temporary-public-storage", "filesytem"] [default: "lhci"]
   --token                        [lhci only] The Lighthouse CI build token for the project.[string]
   --ignoreDuplicateBuildFailure  [lhci only] Whether to ignore failures (still exit with code 0)
                                  caused by uploads of a duplicate build.                   [boolean]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -405,7 +405,7 @@ Saves the runs in the `.lighthouseci/` folder to desired target and sets a GitHu
 Options:
   --target                       The type of target to upload the data to. If set to anything other
                                  than "lhci", some of the options will not apply.
-               [string] [choices: "lhci", "temporary-public-storage", "filesytem"] [default: "lhci"]
+              [string] [choices: "lhci", "temporary-public-storage", "filesystem"] [default: "lhci"]
   --token                        [lhci only] The Lighthouse CI build token for the project.[string]
   --ignoreDuplicateBuildFailure  [lhci only] Whether to ignore failures (still exit with code 0)
                                  caused by uploads of a duplicate build.                   [boolean]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -404,8 +404,9 @@ Saves the runs in the `.lighthouseci/` folder to desired target and sets a GitHu
 ```bash
 Options:
   --target                       The type of target to upload the data to. If set to anything other
-                                 than "lhci", some of the options will not apply.
-                            [string] [choices: "lhci", "temporary-public-storage"] [default: "lhci"]
+                                 than "lhci", some of the options will not apply.          [string]
+                                 [choices: "lhci", "temporary-public-storage", "filesytem"]
+                                 [default: "lhci"]
   --token                        [lhci only] The Lighthouse CI build token for the project.[string]
   --ignoreDuplicateBuildFailure  [lhci only] Whether to ignore failures (still exit with code 0)
                                  caused by uploads of a duplicate build.                   [boolean]


### PR DESCRIPTION
The current documentation lists only `"lhci", "temporary-public-storage"``as targets, however it seems that "filesystem" is also an option. This pull request adds it to the list.