### PR TITLE
Update Docs on SQL Connection URL Format

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -903,7 +903,7 @@ The path to the sqlite database on the local filesystem relative to the current 
 
 _sqlDialect=mysql or sqlDialect=postgres only_
 
-The database connection URL string for the MySQL or PostgreSQL database of the form `<dialect>://<user>:<password>@<host>/<database>`.
+The database connection URL string for the MySQL or PostgreSQL database of the form `<dialect>://<user>:<password>@<host>:<port>/<database>`.
 
 ##### `storage.sqlDangerouslyResetDatabase`
 


### PR DESCRIPTION
Under the covers, it seems that the value of `sqlConnectionUrl` is passed through to Sequelize, so we should be more clear about what's allowed in the format of that string.  Relevant Sequelize documentation on the proper format can be seen here:  https://sequelize.org/v4/manual/installation/getting-started.html#setting-up-a-connection.