### PR TITLE
feat(utils): add build context env for author email (#446)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -610,6 +610,7 @@ The following environment variables override the inferred build context settings
 | `LHCI_BUILD_CONTEXT__CURRENT_BRANCH`     | `dev_branch_1234`                               |
 | `LHCI_BUILD_CONTEXT__COMMIT_MESSAGE`     | `Daily run of Lighthouse`                       |
 | `LHCI_BUILD_CONTEXT__AUTHOR`             | `Patrick Hulce <patrick.hulce@example.com>`     |
+| `LHCI_BUILD_CONTEXT__AUTHOR_EMAIL`       | `patrick.hulce@example.com`                     |
 | `LHCI_BUILD_CONTEXT__AVATAR_URL`         | https://example.com/patrickhulce.jpg            |
 | `LHCI_BUILD_CONTEXT__EXTERNAL_BUILD_URL` | https://my-jenkins.example.com/jobs/123         |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -610,7 +610,6 @@ The following environment variables override the inferred build context settings
 | `LHCI_BUILD_CONTEXT__CURRENT_BRANCH`     | `dev_branch_1234`                               |
 | `LHCI_BUILD_CONTEXT__COMMIT_MESSAGE`     | `Daily run of Lighthouse`                       |
 | `LHCI_BUILD_CONTEXT__AUTHOR`             | `Patrick Hulce <patrick.hulce@example.com>`     |
-| `LHCI_BUILD_CONTEXT__AUTHOR_EMAIL`       | `patrick.hulce@example.com`                     |
 | `LHCI_BUILD_CONTEXT__AVATAR_URL`         | https://example.com/patrickhulce.jpg            |
 | `LHCI_BUILD_CONTEXT__EXTERNAL_BUILD_URL` | https://my-jenkins.example.com/jobs/123         |
 

--- a/packages/utils/src/build-context.js
+++ b/packages/utils/src/build-context.js
@@ -230,27 +230,18 @@ function getAuthor(hash = 'HEAD') {
 }
 
 /**
- * @param {string} hash
+ * @param {string} author
  * @return {string}
  */
-function getAuthorEmail(hash = 'HEAD') {
-  const envHash = getEnvVarIfSet([
-    // Manual override
-    'LHCI_BUILD_CONTEXT__AUTHOR_EMAIL',
-  ]);
-  if (envHash) return envHash;
-
-  const result = childProcess.spawnSync('git', ['log', '--format=%aE', '-n', '1', hash], {
-    encoding: 'utf8',
-  });
-  if (result.status !== 0) {
+function getEmailFromAuthor(author) {
+  const emailRegex = new RegExp(/ <(\S+@\S+)>$/);
+  const emailMatch = author.match(emailRegex);
+  if (!emailMatch) {
     throw new Error(
-      'Unable to determine commit author email with `git log --format=%aE -n 1`. ' +
-        'This can be overridden with setting LHCI_BUILD_CONTEXT__AUTHOR_EMAIL env.'
+      'Unable to parse email from author, expected "' + author + '" to match / <(\\S+@\\S+)>$/'
     );
   }
-
-  return result.stdout.trim();
+  return emailMatch[1];
 }
 
 /**
@@ -264,7 +255,8 @@ function getAvatarUrl(hash = 'HEAD') {
   ]);
   if (envHash) return envHash;
 
-  const email = getAuthorEmail(hash);
+  const author = getAuthor(hash);
+  const email = getEmailFromAuthor(author);
 
   return getGravatarUrlFromEmail(email);
 }
@@ -368,7 +360,7 @@ module.exports = {
   getExternalBuildUrl,
   getCommitMessage,
   getAuthor,
-  getAuthorEmail,
+  getEmailFromAuthor,
   getAvatarUrl,
   getGravatarUrlFromEmail,
   getAncestorHash,

--- a/packages/utils/src/build-context.js
+++ b/packages/utils/src/build-context.js
@@ -233,10 +233,10 @@ function getAuthor(hash = 'HEAD') {
  * @param {string} hash
  * @return {string}
  */
-function getAvatarUrl(hash = 'HEAD') {
+function getAuthorEmail(hash = 'HEAD') {
   const envHash = getEnvVarIfSet([
     // Manual override
-    'LHCI_BUILD_CONTEXT__AVATAR_URL',
+    'LHCI_BUILD_CONTEXT__AUTHOR_EMAIL',
   ]);
   if (envHash) return envHash;
 
@@ -245,12 +245,28 @@ function getAvatarUrl(hash = 'HEAD') {
   });
   if (result.status !== 0) {
     throw new Error(
-      "Unable to determine commit author's avatar URL because `git log --format=%aE -n 1` failed to provide author's email. " +
-        'This can be overridden with setting LHCI_BUILD_CONTEXT__AVATAR_URL env.'
+      'Unable to determine commit author email with `git log --format=%aE -n 1`. ' +
+        'This can be overridden with setting LHCI_BUILD_CONTEXT__AUTHOR_EMAIL env.'
     );
   }
 
-  return getGravatarUrlFromEmail(result.stdout);
+  return result.stdout.trim();
+}
+
+/**
+ * @param {string} hash
+ * @return {string}
+ */
+function getAvatarUrl(hash = 'HEAD') {
+  const envHash = getEnvVarIfSet([
+    // Manual override
+    'LHCI_BUILD_CONTEXT__AVATAR_URL',
+  ]);
+  if (envHash) return envHash;
+
+  const email = getAuthorEmail(hash);
+
+  return getGravatarUrlFromEmail(email);
 }
 
 /**
@@ -352,6 +368,7 @@ module.exports = {
   getExternalBuildUrl,
   getCommitMessage,
   getAuthor,
+  getAuthorEmail,
   getAvatarUrl,
   getGravatarUrlFromEmail,
   getAncestorHash,

--- a/packages/utils/test/build-context.test.js
+++ b/packages/utils/test/build-context.test.js
@@ -110,24 +110,24 @@ describe('build-context.js', () => {
       expect(buildContext.getEmailFromAuthor('Patrick Hulce <a@b>')).toEqual('a@b');
     });
 
-    it('should throw if there is not an @ sign', () => {
-      expect(() => buildContext.getEmailFromAuthor('Patrick Hulce <patrick>')).toThrow();
+    it('returns null if there is not an @ sign', () => {
+      expect(buildContext.getEmailFromAuthor('Patrick Hulce <patrick>')).toBeNull();
     });
 
-    it('should throw if email does not have a user to the left of the @', () => {
-      expect(() => buildContext.getEmailFromAuthor('Patrick Hulce <@gmail.com>')).toThrow();
+    it('returns null if email does not have a user to the left of the @', () => {
+      expect(buildContext.getEmailFromAuthor('Patrick Hulce <@gmail.com>')).toBeNull();
     });
 
-    it('should throw if the user is just whitespace', () => {
-      expect(() => buildContext.getEmailFromAuthor('Patrick Hulce < @gmail.com>')).toThrow();
+    it('returns null if the user is just whitespace', () => {
+      expect(buildContext.getEmailFromAuthor('Patrick Hulce < @gmail.com>')).toBeNull();
     });
 
-    it('should throw if email does not have a host to the right of the @', () => {
-      expect(() => buildContext.getEmailFromAuthor('Patrick Hulce <patrick@>')).toThrow();
+    it('returns null if email does not have a host to the right of the @', () => {
+      expect(buildContext.getEmailFromAuthor('Patrick Hulce <patrick@>')).toBeNull();
     });
 
-    it('should throw if the host is just whitespace', () => {
-      expect(() => buildContext.getEmailFromAuthor('Patrick Hulce <patrick@ >')).toThrow();
+    it('returns null if the host is just whitespace', () => {
+      expect(buildContext.getEmailFromAuthor('Patrick Hulce <patrick@ >')).toBeNull();
     });
 
     it('should ignore angle brackets other than the last pair', () => {
@@ -136,10 +136,8 @@ describe('build-context.js', () => {
       );
     });
 
-    it('should throw if there is not a space between name and email', () => {
-      expect(() =>
-        buildContext.getEmailFromAuthor('Patrick Hulce<patrick.hulce@gmail.com>')
-      ).toThrow();
+    it('returns null if there is not a space between name and email', () => {
+      expect(buildContext.getEmailFromAuthor('Patrick Hulce<patrick.hulce@gmail.com>')).toBeNull();
     });
 
     it('should not be sensitive to the author name itself', () => {
@@ -148,16 +146,14 @@ describe('build-context.js', () => {
       );
     });
 
-    it('should throw if there are not angle brackets surrounding the email', () => {
-      expect(() =>
-        buildContext.getEmailFromAuthor('Patrick Hulce <patrick.hulce@gmail.com')
-      ).toThrow();
+    it('returns null if there are not angle brackets surrounding the email', () => {
+      expect(buildContext.getEmailFromAuthor('Patrick Hulce <patrick.hulce@gmail.com')).toBeNull();
     });
 
-    it('should throw if the email is not at the end of the string', () => {
-      expect(() =>
+    it('returns null if the email is not at the end of the string', () => {
+      expect(
         buildContext.getEmailFromAuthor('Patrick Hulce <patrick.hulce@gmail.com> ')
-      ).toThrow();
+      ).toBeNull();
     });
   });
 
@@ -171,6 +167,20 @@ describe('build-context.js', () => {
     it('should respect env override', () => {
       process.env.LHCI_BUILD_CONTEXT__AVATAR_URL = 'http://localhost:1234/profile.jpg';
       expect(buildContext.getAvatarUrl(hash)).toEqual('http://localhost:1234/profile.jpg');
+    });
+
+    it('should parse email from the complete author env override', () => {
+      process.env.LHCI_BUILD_CONTEXT__AUTHOR = 'Paul Irish <paulirish@google.com>';
+      expect(buildContext.getAvatarUrl(hash)).toEqual(
+        'https://www.gravatar.com/avatar/629999fcb3f6a928abe5f65ed0ab09c2.jpg?d=identicon'
+      );
+    });
+
+    it('should use git if author env override does not have an email', () => {
+      process.env.LHCI_BUILD_CONTEXT__AUTHOR = 'Paul Irish <localhost>';
+      expect(buildContext.getAvatarUrl(hash)).toEqual(
+        'https://www.gravatar.com/avatar/78bafdcaf40e20b90bb76b9aa5834e11.jpg?d=identicon'
+      );
     });
   });
 

--- a/packages/utils/test/build-context.test.js
+++ b/packages/utils/test/build-context.test.js
@@ -99,14 +99,65 @@ describe('build-context.js', () => {
     });
   });
 
-  describe('#getAuthorEmail()', () => {
+  describe('#getEmailFromAuthor', () => {
     it('should work', () => {
-      expect(buildContext.getAuthorEmail(hash)).toEqual('patrick.hulce@gmail.com');
+      expect(buildContext.getEmailFromAuthor('Patrick Hulce <patrick.hulce@gmail.com>')).toEqual(
+        'patrick.hulce@gmail.com'
+      );
     });
 
-    it('should respect env override', () => {
-      process.env.LHCI_BUILD_CONTEXT__AUTHOR_EMAIL = 'paulirish@google.com';
-      expect(buildContext.getAuthorEmail(hash)).toEqual('paulirish@google.com');
+    it('should not be overly strict about email format', () => {
+      expect(buildContext.getEmailFromAuthor('Patrick Hulce <a@b>')).toEqual('a@b');
+    });
+
+    it('should throw if there is not an @ sign', () => {
+      expect(() => buildContext.getEmailFromAuthor('Patrick Hulce <patrick>')).toThrow();
+    });
+
+    it('should throw if email does not have a user to the left of the @', () => {
+      expect(() => buildContext.getEmailFromAuthor('Patrick Hulce <@gmail.com>')).toThrow();
+    });
+
+    it('should throw if the user is just whitespace', () => {
+      expect(() => buildContext.getEmailFromAuthor('Patrick Hulce < @gmail.com>')).toThrow();
+    });
+
+    it('should throw if email does not have a host to the right of the @', () => {
+      expect(() => buildContext.getEmailFromAuthor('Patrick Hulce <patrick@>')).toThrow();
+    });
+
+    it('should throw if the host is just whitespace', () => {
+      expect(() => buildContext.getEmailFromAuthor('Patrick Hulce <patrick@ >')).toThrow();
+    });
+
+    it('should ignore angle brackets other than the last pair', () => {
+      expect(buildContext.getEmailFromAuthor('Patrick Hulce <fir@st> <se@cond>')).toEqual(
+        'se@cond'
+      );
+    });
+
+    it('should throw if there is not a space between name and email', () => {
+      expect(() =>
+        buildContext.getEmailFromAuthor('Patrick Hulce<patrick.hulce@gmail.com>')
+      ).toThrow();
+    });
+
+    it('should not be sensitive to the author name itself', () => {
+      expect(buildContext.getEmailFromAuthor(' <patrick.hulce@gmail.com>')).toEqual(
+        'patrick.hulce@gmail.com'
+      );
+    });
+
+    it('should throw if there are not angle brackets surrounding the email', () => {
+      expect(() =>
+        buildContext.getEmailFromAuthor('Patrick Hulce <patrick.hulce@gmail.com')
+      ).toThrow();
+    });
+
+    it('should throw if the email is not at the end of the string', () => {
+      expect(() =>
+        buildContext.getEmailFromAuthor('Patrick Hulce <patrick.hulce@gmail.com> ')
+      ).toThrow();
     });
   });
 

--- a/packages/utils/test/build-context.test.js
+++ b/packages/utils/test/build-context.test.js
@@ -99,6 +99,17 @@ describe('build-context.js', () => {
     });
   });
 
+  describe('#getAuthorEmail()', () => {
+    it('should work', () => {
+      expect(buildContext.getAuthorEmail(hash)).toEqual('patrick.hulce@gmail.com');
+    });
+
+    it('should respect env override', () => {
+      process.env.LHCI_BUILD_CONTEXT__AUTHOR_EMAIL = 'paulirish@google.com';
+      expect(buildContext.getAuthorEmail(hash)).toEqual('paulirish@google.com');
+    });
+  });
+
   describe('#getAvatarUrl()', () => {
     it('should work', () => {
       expect(buildContext.getAvatarUrl(hash)).toEqual(


### PR DESCRIPTION
Adds `LHCI_BUILD_CONTEXT__AUTHOR_EMAIL` environment variable to override getting the commit author's email from git, and uses this to get the gravatar URL when `LHCI_BUILD_CONTEXT__AVATAR_URL` is not specified.

Resolves #446 

