### PR TITLE
Add flag to filter out URLs you don't want to be tested

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,6 +207,8 @@ Options:
                              multiple URLs.
   --staticDistDir            The build directory where your HTML files to run Lighthouse on are
                              located.
+  --filterUrl                A URL to not include in Lighthouse testing when using staticDistDir.
+                             Use this flag multiple times to filter multiple URLs.
   --isSinglePageApplication  If the application is created by Single Page Application, enable
                              redirect to index.html.
   --chromePath               The path to the Chrome or Chromium executable to use for collection.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,7 +207,7 @@ Options:
                              multiple URLs.
   --staticDistDir            The build directory where your HTML files to run Lighthouse on are
                              located.
-  --filterUrl                A URL to not include in Lighthouse testing when using staticDistDir.
+  --autodiscoverUrlBlocklist A URL to not include when autodiscovering urls from staticDistDir.
                              Use this flag multiple times to filter multiple URLs.
   --isSinglePageApplication  If the application is created by Single Page Application, enable
                              redirect to index.html.

--- a/packages/cli/src/collect/collect.js
+++ b/packages/cli/src/collect/collect.js
@@ -191,7 +191,7 @@ async function startServerAndDetermineUrls(options) {
         return url.href;
       }
     );
-    const urlsToUse = availableUrls.filter(url => !normalizedBlocklist.includes(url)).slice(0, maxNumberOfUrls)
+    const urlsToUse = availableUrls.filter(url => !normalizedBlocklist.includes(url)).slice(0, maxNumberOfUrls);
     urls.push(...urlsToUse);
   }
 

--- a/packages/cli/src/collect/collect.js
+++ b/packages/cli/src/collect/collect.js
@@ -184,14 +184,14 @@ async function startServerAndDetermineUrls(options) {
       ? [options.autodiscoverUrlBlocklist]
       : [];
     const availableUrls = server.getAvailableUrls();
-    const normalizedBlocklist = autodiscoverUrlBlocklistAsArray.map(
-      rawUrl => {
-        const url = new URL(rawUrl, 'http://localhost');
-        url.port = server.port.toString();
-        return url.href;
-      }
-    );
-    const urlsToUse = availableUrls.filter(url => !normalizedBlocklist.includes(url)).slice(0, maxNumberOfUrls);
+    const normalizedBlocklist = autodiscoverUrlBlocklistAsArray.map(rawUrl => {
+      const url = new URL(rawUrl, 'http://localhost');
+      url.port = server.port.toString();
+      return url.href;
+    });
+    const urlsToUse = availableUrls
+      .filter(url => !normalizedBlocklist.includes(url))
+      .slice(0, maxNumberOfUrls);
     urls.push(...urlsToUse);
   }
 

--- a/packages/cli/src/collect/collect.js
+++ b/packages/cli/src/collect/collect.js
@@ -39,6 +39,10 @@ function buildCommand(yargs) {
       description:
         'A URL to run Lighthouse on. Use this flag multiple times to evaluate multiple URLs.',
     },
+    filterUrl: {
+      description:
+        'A URL to not include in Lighthouse testing when using staticDistDir. Use this flag multiple times to filter multiple URLs.',
+    },
     psiApiKey: {
       description: '[psi only] The API key to use for PageSpeed Insights runner method.',
     },
@@ -174,7 +178,13 @@ async function startServerAndDetermineUrls(options) {
   const urls = urlsAsArray;
   if (!urls.length) {
     const maxNumberOfUrls = options.maxAutodiscoverUrls || Infinity;
-    urls.push(...server.getAvailableUrls().slice(0, maxNumberOfUrls));
+    const filterUrlsAsArray = Array.isArray(options.filterUrl)
+      ? options.filterUrl
+      : options.filterUrl
+      ? [options.filterUrl]
+      : [];
+    urls.push(...server.getAvailableUrls().filter(url => 
+      !filterUrlsAsArray.some(pattern => url.endsWith(":" + server.port + pattern))).slice(0, maxNumberOfUrls));
   }
 
   if (!urls.length) {

--- a/packages/cli/test/collect-puppeteer.test.js
+++ b/packages/cli/test/collect-puppeteer.test.js
@@ -90,9 +90,9 @@ describe('Lighthouse CI collect CLI with puppeteer', () => {
     const chromePathHelp = stdout.match(/--chromePath.*\n.*\n.*/);
     expect(chromePathHelp).toMatchInlineSnapshot(`
       Array [
-        "--chromePath               The path to the Chrome or Chromium executable to use for collection.
-        --puppeteerScript          The path to a script that manipulates the browser with puppeteer before running Lighthouse, used for auth.
-        --puppeteerLaunchOptions   The object of puppeteer launch options",
+        "--chromePath                The path to the Chrome or Chromium executable to use for collection.
+        --puppeteerScript           The path to a script that manipulates the browser with puppeteer before running Lighthouse, used for auth.
+        --puppeteerLaunchOptions    The object of puppeteer launch options",
       ]
     `);
     expect(stderr).toMatchInlineSnapshot(`""`);

--- a/packages/cli/test/collect-static-dir.test.js
+++ b/packages/cli/test/collect-static-dir.test.js
@@ -111,12 +111,7 @@ describe('Lighthouse CI collect CLI', () => {
 
     it('should filter index file', async () => {
       const {stdout, stderr, status} = await runCLI(
-        [
-          'collect',
-          '-n=1',
-          '--staticDistDir=./',
-          '--autodiscoverUrlBlocklist=/index.html',
-        ],
+        ['collect', '-n=1', '--staticDistDir=./', '--autodiscoverUrlBlocklist=/index.html'],
         {
           cwd: staticDistDir,
         }

--- a/packages/cli/test/collect-static-dir.test.js
+++ b/packages/cli/test/collect-static-dir.test.js
@@ -82,6 +82,95 @@ describe('Lighthouse CI collect CLI', () => {
       expect(status).toEqual(0);
     }, 180000);
   });
+
+  describe('with filterurl', () => {
+    const staticDistDir = path.join(__dirname, 'fixtures/collect-static-dir-autodiscover-limit');
+    it('should not filter any files because it was not tested', async () => {
+      const {stdout, stderr, status} = await runCLI(
+        [
+          'collect',
+          '-n=1',
+          '--staticDistDir=./',
+          '--maxAutodiscoverUrls=1',
+          '--filterUrl=/team.html',
+        ],
+        {
+          cwd: staticDistDir,
+        }
+      );
+      expect(stdout).toMatchInlineSnapshot(`
+          "Started a web server on port XXXX...
+          Running Lighthouse 1 time(s) on http://localhost:XXXX/board.html
+          Run #1...done.
+          Done running Lighthouse!
+          "
+          `);
+      expect(stderr).toMatchInlineSnapshot(`""`);
+      expect(status).toEqual(0);
+    }, 180000);
+
+    it('should filter index file', async () => {
+      const {stdout, stderr, status} = await runCLI(
+        [
+          'collect',
+          '-n=1',
+          '--staticDistDir=./',
+          '--filterUrl=/index.html',
+        ],
+        {
+          cwd: staticDistDir,
+        }
+      );
+      expect(stdout).toMatchInlineSnapshot(`
+          "Started a web server on port XXXX...
+          Running Lighthouse 1 time(s) on http://localhost:XXXX/board.html
+          Run #1...done.
+          Running Lighthouse 1 time(s) on http://localhost:XXXX/checkout.html
+          Run #1...done.
+          Running Lighthouse 1 time(s) on http://localhost:XXXX/jobs.html
+          Run #1...done.
+          Running Lighthouse 1 time(s) on http://localhost:XXXX/shop.html
+          Run #1...done.
+          Running Lighthouse 1 time(s) on http://localhost:XXXX/team.html
+          Run #1...done.
+          Done running Lighthouse!
+          "
+          `);
+      expect(stderr).toMatchInlineSnapshot(`""`);
+      expect(status).toEqual(0);
+    }, 180000);
+
+    it('should filter index file and board file', async () => {
+      const {stdout, stderr, status} = await runCLI(
+        [
+          'collect',
+          '-n=1',
+          '--staticDistDir=./',
+          '--filterUrl=/index.html',
+          '--filterUrl=/board.html',
+        ],
+        {
+          cwd: staticDistDir,
+        }
+      );
+      expect(stdout).toMatchInlineSnapshot(`
+          "Started a web server on port XXXX...
+          Running Lighthouse 1 time(s) on http://localhost:XXXX/checkout.html
+          Run #1...done.
+          Running Lighthouse 1 time(s) on http://localhost:XXXX/jobs.html
+          Run #1...done.
+          Running Lighthouse 1 time(s) on http://localhost:XXXX/shop.html
+          Run #1...done.
+          Running Lighthouse 1 time(s) on http://localhost:XXXX/team.html
+          Run #1...done.
+          Done running Lighthouse!
+          "
+          `);
+      expect(stderr).toMatchInlineSnapshot(`""`);
+      expect(status).toEqual(0);
+    }, 180000);
+  });
+
   describe('by default', () => {
     const staticDistDir = path.join(__dirname, 'fixtures/collect-static-dir-autodiscover-limit');
 

--- a/packages/cli/test/collect-static-dir.test.js
+++ b/packages/cli/test/collect-static-dir.test.js
@@ -83,7 +83,7 @@ describe('Lighthouse CI collect CLI', () => {
     }, 180000);
   });
 
-  describe('with filterurl', () => {
+  describe('with autodiscoverUrlBlocklist', () => {
     const staticDistDir = path.join(__dirname, 'fixtures/collect-static-dir-autodiscover-limit');
     it('should not filter any files because it was not tested', async () => {
       const {stdout, stderr, status} = await runCLI(
@@ -92,7 +92,7 @@ describe('Lighthouse CI collect CLI', () => {
           '-n=1',
           '--staticDistDir=./',
           '--maxAutodiscoverUrls=1',
-          '--filterUrl=/team.html',
+          '--autodiscoverUrlBlocklist=/team.html',
         ],
         {
           cwd: staticDistDir,
@@ -115,7 +115,7 @@ describe('Lighthouse CI collect CLI', () => {
           'collect',
           '-n=1',
           '--staticDistDir=./',
-          '--filterUrl=/index.html',
+          '--autodiscoverUrlBlocklist=/index.html',
         ],
         {
           cwd: staticDistDir,
@@ -146,8 +146,8 @@ describe('Lighthouse CI collect CLI', () => {
           'collect',
           '-n=1',
           '--staticDistDir=./',
-          '--filterUrl=/index.html',
-          '--filterUrl=/board.html',
+          '--autodiscoverUrlBlocklist=/index.html',
+          '--autodiscoverUrlBlocklist=/board.html',
         ],
         {
           cwd: staticDistDir,

--- a/types/collect.d.ts
+++ b/types/collect.d.ts
@@ -44,6 +44,7 @@ declare global {
 
       export interface Options {
         url?: string | string[];
+        filterUrl?: string | string[];
         psiApiKey?: string;
         psiApiEndpoint?: string;
         staticDistDir?: string;

--- a/types/collect.d.ts
+++ b/types/collect.d.ts
@@ -44,7 +44,7 @@ declare global {
 
       export interface Options {
         url?: string | string[];
-        filterUrl?: string | string[];
+        autodiscoverUrlBlocklist?: string | string[];
         psiApiKey?: string;
         psiApiEndpoint?: string;
         staticDistDir?: string;


### PR DESCRIPTION
This PR allows you to filter out certain URLs that you would like to be skipped over during testing. This is used alongside staticDistDir and is not functional with url (Not sure how exactly that would end up working).