### PR TITLE
docs: bump lhci from 0.4.x to 0.5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
-      - run: npm install && npm install -g @lhci/cli@0.4.x
+      - run: npm install && npm install -g @lhci/cli@0.5.x
       - run: npm run build
       - run: lhci autorun
 ```

--- a/docs/complex-setup.md
+++ b/docs/complex-setup.md
@@ -24,7 +24,7 @@ fi
 
 npm run deploy
 
-npm install -g @lhci/cli@0.4.x
+npm install -g @lhci/cli@0.5.x
 lhci healthcheck --fatal
 lhci collect --url=http://localhost:9000/index.html
 lhci assert --preset="lighthouse:recommended"
@@ -121,7 +121,7 @@ Now that we have our environment ready, time to run Lighthouse CI. The `collect`
 
 # Install Lighthouse CI
 # If you're already using node to manage your project, add it to your package.json `devDependencies` instead to skip this step.
-npm install -g @lhci/cli@0.4.x
+npm install -g @lhci/cli@0.5.x
 
 # Run a healthcheck to make sure everything looks good before we run collection.
 lhci healthcheck --fatal

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,7 +94,7 @@ jobs:
           npm run build
       - name: run Lighthouse CI
         run: |
-          npm install -g @lhci/cli@0.4.x
+          npm install -g @lhci/cli@0.5.x
           lhci autorun
 ```
 
@@ -112,7 +112,7 @@ node_js: v12
 addons:
   chrome: stable
 before_install:
-  - npm install -g @lhci/cli@0.4.x
+  - npm install -g @lhci/cli@0.5.x
 script:
   - npm run build
   - lhci autorun
@@ -137,7 +137,7 @@ jobs:
       - checkout
       - run: npm install
       - run: npm run build
-      - run: sudo npm install -g @lhci/cli@0.4.x
+      - run: sudo npm install -g @lhci/cli@0.5.x
       - run: lhci autorun
 ```
 
@@ -172,7 +172,7 @@ lhci:
   script:
     - npm install
     - npm run build
-    - npm install -g @lhci/cli@0.4.x
+    - npm install -g @lhci/cli@0.5.x
     - lhci autorun --upload.target=temporary-public-storage --collect.settings.chromeFlags="--no-sandbox" || echo "LHCI failed!"
 ```
 
@@ -214,7 +214,7 @@ npm run build
 export CHROME_PATH=$(which google-chrome-stable)
 export LHCI_BUILD_CONTEXT__EXTERNAL_BUILD_URL="$BUILD_URL"
 
-npm install -g @lhci/cli@0.4.x
+npm install -g @lhci/cli@0.5.x
 lhci autorun
 ```
 
@@ -383,7 +383,7 @@ Once the server is set up, _on your local laptop or desktop_, make sure you can 
 ```bash
 $ curl https://your-lhci-server.example.com/version # Make sure you can connect to your server.
 0.x.x
-$ npm install -g @lhci/cli@0.4.x # Install the Lighthouse CI CLI.
+$ npm install -g @lhci/cli@0.5.x # Install the Lighthouse CI CLI.
 Installing...
 $ lhci wizard # Use the wizard to create a project.
 ? Which wizard do you want to run? new-project


### PR DESCRIPTION
I fixed document to fit current version.
I think it would be used `latest`.

```
npm install -g @lhci/cli@latest
```