### PR TITLE
fix(utils): handle missing details.items

### DIFF
--- a/packages/utils/src/assertions.js
+++ b/packages/utils/src/assertions.js
@@ -40,7 +40,7 @@ const AUDIT_TYPE_VALUE_GETTERS = {
     if (result.scoreDisplayMode === 'informative') return 0;
     return undefined;
   },
-  maxLength: result => result.details && result.details.items && result.details.items.length,
+  maxLength: result => (result.details && result.details.items && result.details.items.length) || 0,
   maxNumericValue: result => result.numericValue,
 };
 

--- a/packages/utils/test/assertions.test.js
+++ b/packages/utils/test/assertions.test.js
@@ -209,6 +209,27 @@ describe('getAllAssertionResults', () => {
     expect(results).toMatchObject([{actual: 0.8, expected: 0.9}]);
   });
 
+  it('should assume a default items length of 0', () => {
+    const assertions = {
+      'first-contentful-paint': ['error', {maxLength: 10}],
+    };
+
+    const results = getAllAssertionResults({assertions, includePassedAssertions: true}, lhrs);
+    expect(results).toEqual([
+      {
+        actual: 0,
+        auditId: 'first-contentful-paint',
+        expected: 10,
+        level: 'error',
+        name: 'maxLength',
+        operator: '<=',
+        passed: true,
+        url: 'http://page-1.com',
+        values: [0, 0],
+      },
+    ]);
+  });
+
   it('should warn on incorrect assertion type', () => {
     const assertions = {
       'network-requests': ['error', {maxNumericValue: 10}],


### PR DESCRIPTION
Some audits will not have a `.details.items` array at all when they pass, even though they support `.details.items` so Lighthouse CI needs to support this case.

fixes https://github.com/GoogleChrome/lighthouse-ci/issues/481