### PR TITLE
feat: scrollable project list

### DIFF
--- a/packages/server/src/ui/layout/page-sidebar.css
+++ b/packages/server/src/ui/layout/page-sidebar.css
@@ -46,7 +46,9 @@
 }
 
 .page-sidebar__content {
-  padding: 0 var(--page-header-horizontal-padding);
+  padding: 0 var(--page-header-horizontal-padding) var(--page-header-vertical-padding) var(--page-header-horizontal-padding);
+  max-height: calc(100% - var(--subtext-font-size) - var(--page-header-height) - var(--page-header-vertical-padding) * 2);
+  overflow: auto;
 }
 
 .page-sidebar__content ul {

--- a/packages/server/src/ui/routes/project-list/project-list.css
+++ b/packages/server/src/ui/routes/project-list/project-list.css
@@ -25,8 +25,10 @@
 
 .project-list .paper {
   max-width: 50vw;
+  max-height: 100%;
   padding: calc(var(--paper-padding) * 2);
   z-index: 2;
+  overflow: auto;
 }
 
 .project-list img {


### PR DESCRIPTION
The project list was hidden from view when I registered a lot of projects.
I fixed scrollable.

before
![Screenshot from 2020-11-12 19-45-45](https://user-images.githubusercontent.com/1889831/98930411-f33ce400-251f-11eb-990e-c71f532a0299.png)
after
![Screenshot from 2020-11-12 19-47-30](https://user-images.githubusercontent.com/1889831/98930424-f8019800-251f-11eb-9db5-e968e099b81a.png)
