### PR TITLE
Adding in Cloudbuild documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -268,7 +268,7 @@ steps:
       - 'LHCI_BUILD_CONTEXT__CURRENT_BRANCH=$BRANCH_NAME'
 
 options:
-  machineType: 'N1_HIGHCPU_32'
+  machineType: 'N1_HIGHCPU_8'
 ```
 
 </details>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -244,7 +244,7 @@ module.exports = {
 
 **Notes**
 * `LHCI_BUILD_CONTEXT__CURRENT_BRANCH` doesn't pick up the right variables in cloudbuild so passing through `$BRANCH_NAME` will fix this.
-* `machineType` defines the machine you can pick. The bigger the better (see: https://github.com/GoogleChrome/lighthouse/blob/master/docs/variability.md). Look through the [Cloudbuild machine pricing](https://cloud.google.com/cloud-build/pricing)
+* `machineType` defines the machine you can pick. The bigger the machine the more stable the performance results will be (see [Lighthouse variability documentation](https://github.com/GoogleChrome/lighthouse/blob/master/docs/variability.md)). WARNING: Look through the [Cloudbuild machine pricing](https://cloud.google.com/cloud-build/pricing) before deciding on a machine type.
 
 **cloudbuild.yml**
 

--- a/docs/introduction-to-ci.md
+++ b/docs/introduction-to-ci.md
@@ -32,3 +32,4 @@ There are many CI providers out there to choose from. Lighthouse CI works with a
 - [GitLab CI](https://docs.gitlab.com/ee/ci/quick_start/)
 - [Travis CI](https://docs.travis-ci.com/user/tutorial/)
 - [Circle CI](https://circleci.com/docs/2.0/getting-started/)
+- [Google Cloudbuild](https://cloud.google.com/cloud-build/docs/quickstart-build)


### PR DESCRIPTION
Thought it'd be good to add in Google Cloudbuild. I've also upgraded the referred image on GitLab as that image doesn't seem to work with Lighthouse 6.

We're running on HIGHCPU_32 as it delivers the best and most consistent results (and HIGHCPU_8) is similar to Github Actions which doesn't return consistent results.