### PR TITLE
Upgrade upstream lighthouse dependency to version 6.5.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,7 @@
     "express": "^4.17.1",
     "inquirer": "^6.3.1",
     "isomorphic-fetch": "^2.2.1",
-    "lighthouse": "6.4.1",
+    "lighthouse": "6.5.0",
     "lighthouse-logger": "1.2.0",
     "open": "^7.1.0",
     "tmp": "^0.1.0",


### PR DESCRIPTION
I had noticed a warning while viewing Lighthouse reports lately.

> Warning: Results may not display properly. Report was created with an earlier version of Lighthouse (6.4.1). The latest version is 6.5.0.

It seems that there was an upstream release to a dependency.  Opening a PR to pull in the latest upstream version.