### PR TITLE
readme quick start use the new actions/setup-node@v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
       - run: npm install && npm install -g @lhci/cli@0.6.x
       - run: npm run build
       - run: lhci autorun


### PR DESCRIPTION
The stable release of `actions/setup-node@v2` landed two weeks ago:

https://github.com/actions/setup-node/releases/tag/v2.1.4