### PR TITLE
feat(server): add a health check route before auth

### DIFF
--- a/docs/recipes/docker-server/kubernetes/lhci-deployment.yml
+++ b/docs/recipes/docker-server/kubernetes/lhci-deployment.yml
@@ -26,7 +26,7 @@ spec:
             - containerPort: 9001
           readinessProbe:
             httpGet:
-              path: /app/
+              path: /healthz
               port: 9001
       volumes:
         - name: lhci-data-volume

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -44,7 +44,10 @@ async function createApp(options) {
   // 2. Support JSON primitives because `PUT /builds/<id>/lifecycle "sealed"`
   app.use(bodyParser.json({limit: '10mb', strict: false}));
 
-  // The entire server can be protected by HTTP Basic Authentication
+  // Add a health check route before auth
+  app.use('/healthz', (_, res) => res.send('healthy'));
+
+  // The rest of the server can be protected by HTTP Basic Authentication
   const authMiddleware = createBasicAuthMiddleware(context);
   if (authMiddleware) app.use(authMiddleware);
 

--- a/packages/server/test/basic-auth-server.test.js
+++ b/packages/server/test/basic-auth-server.test.js
@@ -77,5 +77,10 @@ describe('sqlite server (authenticated)', () => {
         expect(body.length).toBeGreaterThan(4);
       });
     }
+
+    it(`should allow unauthorized requests for /healthz`, async () => {
+      const response = await fetch(`http://localhost:${state.port}/healthz`);
+      expect(response.status).toEqual(200);
+    });
   });
 });

--- a/packages/server/test/server-test-suite.js
+++ b/packages/server/test/server-test-suite.js
@@ -31,6 +31,17 @@ function runTests(state) {
     client = new ApiClient({rootURL, extraHeaders: state.extraHeaders});
   });
 
+  describe('/healthz', () => {
+    it('should return healthy', async () => {
+      const response = await fetch(`${rootURL}/healthz`, {
+        extraHeaders: state.extraHeaders,
+      });
+      expect(response.status).toEqual(200);
+      const responseText = await response.text();
+      expect(responseText).toEqual('healthy');
+    });
+  });
+
   describe('/version', () => {
     it('should return the version', async () => {
       const version = await client.getVersion();


### PR DESCRIPTION
Google Kubernetes Engine default ingress requires a health check route that returns a 200 response. If basic authentication is enabled, there is no route that can be used for a health check. This PR adds a `/healthz` route before the auth middleware to be used for health checks.