### PR TITLE
build(deps-cli): fix npm vulnerabilities

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,14 +18,14 @@
     "compression": "^1.7.4",
     "express": "^4.17.1",
     "inquirer": "^6.3.1",
-    "isomorphic-fetch": "^2.2.1",
+    "isomorphic-fetch": "^3.0.0",
     "lighthouse": "6.4.1",
     "lighthouse-logger": "1.2.0",
     "open": "^7.1.0",
     "tmp": "^0.1.0",
     "update-notifier": "^3.0.1",
     "uuid": "^8.3.1",
-    "yargs": "^12.0.5",
-    "yargs-parser": "^13.1.2"
+    "yargs": "^16.2.0",
+    "yargs-parser": "^20.2.4"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "tmp": "^0.1.0",
     "update-notifier": "^3.0.1",
     "uuid": "^8.3.1",
-    "yargs": "^16.2.0",
-    "yargs-parser": "^20.2.4"
+    "yargs": "^15.4.2",
+    "yargs-parser": "^13.1.2"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "tmp": "^0.1.0",
     "update-notifier": "^3.0.1",
     "uuid": "^8.3.1",
-    "yargs": "^15.4.2",
+    "yargs": "^15.4.1",
     "yargs-parser": "^13.1.2"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "dependencies": {
-    "isomorphic-fetch": "^2.2.1",
+    "isomorphic-fetch": "^3.0.0",
     "js-yaml": "^3.13.1",
     "lighthouse": "6.4.1",
     "tree-kill": "^1.2.1"


### PR DESCRIPTION
When installing `@lhci/cli`, npm show us "4 low severity vulnerabilities" : 
![Capture1_43](https://user-images.githubusercontent.com/25207499/104634064-6984d080-56a0-11eb-9154-3fdd221fb48b.png)
![Capture1_44](https://user-images.githubusercontent.com/25207499/104634067-6ab5fd80-56a0-11eb-9bcd-10f02bd38426.png)

We should not use dependencies with vulnerabilities.

In the future to avoid these sort of things, we could use [dependabot](https://dependabot.com/), it is a builtin solution in GitHub to automatically update dependencies.

**Link about the vulnerabilities :**
- https://www.npmjs.com/advisories/1500/versions
- https://www.npmjs.com/advisories/1556

**What changes this PR introduce ?**

- Bump `isomorphic-fetch` from 2.2.1 to 3.0.0
  See: https://github.com/matthew-andrews/isomorphic-fetch/issues/192
  The only things to be aware by doing this upgrade : "Node.js 0.10.x and 0.12.x support is dropped"
- Bump `yargs` from 12.0.5 to 15.4.1
  Didn't check what need to change in the codebase to support the latest version of `yargs` but hopefully the `ci` pass and 
  everything is fine, if not we would need to see what's the breaking changes in the few releases of `yargs` and update the code 
  base accordingly.