### PR TITLE
limit the length of build context for commit messages and authors from ENV too

### DIFF
--- a/packages/utils/src/build-context.js
+++ b/packages/utils/src/build-context.js
@@ -194,7 +194,7 @@ function getCommitMessage(hash = 'HEAD') {
     // Manual override
     'LHCI_BUILD_CONTEXT__COMMIT_MESSAGE',
   ]);
-  if (envHash) return envHash;
+  if (envHash) return envHash.trim().slice(0, 80);
 
   const result = childProcess.spawnSync('git', ['log', '--format=%s', '-n', '1', hash], {
     encoding: 'utf8',
@@ -218,7 +218,7 @@ function getAuthor(hash = 'HEAD') {
     // Manual override
     'LHCI_BUILD_CONTEXT__AUTHOR',
   ]);
-  if (envHash) return envHash;
+  if (envHash) return envHash.trim().slice(0, 256);
 
   const result = childProcess.spawnSync('git', ['log', '--format=%aN <%aE>', '-n', '1', hash], {
     encoding: 'utf8',


### PR DESCRIPTION
whether these strings come from git or ENV they need to be truncated since the upstream server enforces these character limits.

Otherwise, users will get the following exception:

```
Error: Unexpected status code 422
--
  | {"message":"value too long for type character varying(80)"}
  | at ApiClient._convertFetchResponseToReturnValue (/usr/local/lib/node_modules/@lhci/cli/node_modules/@lhci/utils/src/api-client.js:79:21)
  | at processTicksAndRejections (internal/process/task_queues.js:93:5)
  | at async runLHCITarget (/usr/local/lib/node_modules/@lhci/cli/src/upload/upload.js:409:17)
  | at async Object.runCommand (/usr/local/lib/node_modules/@lhci/cli/src/upload/upload.js:592:16)
  | at async run (/usr/local/lib/node_modules/@lhci/cli/src/cli.js:109:7)
```
