### PR TITLE
fix(cli/upload): GithubStatus check fix failedResults/warnResults

### DIFF
--- a/packages/cli/src/upload/upload.js
+++ b/packages/cli/src/upload/upload.js
@@ -165,6 +165,9 @@ async function postStatusToGitHub(options) {
   } else {
     const url = `${githubApiHost}/repos/${slug}/statuses/${hash}`;
     const payload = {state, context, description, target_url: targetUrl};
+    if (process.env.NODE_ENV === 'test') {
+      console.debug(payload);
+    }
     response = await fetch(url, {
       method: 'POST',
       headers: {'Content-Type': 'application/json', Authorization: `token ${githubToken}`},

--- a/packages/cli/src/upload/upload.js
+++ b/packages/cli/src/upload/upload.js
@@ -250,8 +250,8 @@ async function runGithubStatusCheck(options, targetUrlMap) {
     for (const group of groupedResults) {
       const rawUrl = group[0].url;
       const urlLabel = getUrlLabelForGithub(rawUrl, options);
-      const failedResults = group.filter(result => result.level === 'error');
-      const warnResults = group.filter(result => result.level === 'warn');
+      const failedResults = group.filter(result => result.level === 'error' && !result.passed);
+      const warnResults = group.filter(result => result.level === 'warn' && !result.passed);
       const state = failedResults.length ? 'failure' : 'success';
       const context = getGitHubContext(urlLabel, options);
       const warningsLabel = warnResults.length ? ` with ${warnResults.length} warning(s)` : '';

--- a/packages/cli/test/autorun-github.test.js
+++ b/packages/cli/test/autorun-github.test.js
@@ -91,9 +91,9 @@ describe('Lighthouse CI autorun CLI with GitHub status check', () => {
       {\\"message\\":\\"Bad credentials\\",\\"documentation_url\\":\\"https://docs.github.com/rest\\"}
 
       {
-        state: 'failure',
+        state: 'success',
         context: 'lhci/url/good.html',
-        description: 'Failed 1 assertion(s)',
+        description: 'Passed',
         target_url: 'https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/XXXX-XXXX.report.html'
       }
       GitHub responded with 401

--- a/packages/cli/test/autorun-github.test.js
+++ b/packages/cli/test/autorun-github.test.js
@@ -1,0 +1,134 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+const path = require('path');
+const rimraf = require('rimraf');
+const fs = require('fs');
+const ApiClient = require('@lhci/utils/src/api-client.js');
+
+const {runCLI, startServer, safeDeleteFile} = require('./test-utils.js');
+
+describe('Lighthouse CI autorun CLI with GitHub status check', () => {
+  const autorunDir = path.join(__dirname, 'fixtures/autorun-github');
+  const lighthouseciDir = path.join(autorunDir, '.lighthouseci');
+
+  let server;
+  let serverBaseUrl;
+  let apiClient;
+  let project;
+
+  beforeAll(async () => {
+    if (fs.existsSync(lighthouseciDir)) rimraf.sync(lighthouseciDir);
+
+    server = await startServer();
+    serverBaseUrl = `http://localhost:${server.port}/`;
+
+    apiClient = new ApiClient({rootURL: serverBaseUrl});
+    project = await apiClient.createProject({name: 'Test'});
+  });
+
+  afterAll(async () => {
+    if (server) {
+      server.process.kill();
+      await safeDeleteFile(server.sqlFile);
+    }
+  });
+
+  it('should submit status check to GitHub', async () => {
+    const {stdout, stderr, status} = await runCLI(
+      [
+        'autorun',
+        '--upload.githubToken=githubToken',
+        `--upload.serverBaseUrl=${serverBaseUrl}`,
+        `--upload.token=${project.token}`,
+      ],
+      {
+        cwd: autorunDir,
+        env: {
+          LHCI_BUILD_CONTEXT__CURRENT_HASH: '68d085acb61c317ce29fe32f95599c56b0f95a8c',
+          LHCI_BUILD_CONTEXT__GITHUB_REPO_SLUG: 'GoogleChrome/lighthouse-ci',
+          LHCI_NO_LIGHTHOUSERC: undefined,
+        },
+      }
+    );
+
+    expect(stdout).toMatchInlineSnapshot(`
+      "✅  .lighthouseci/ directory writable
+      ✅  Configuration file found
+      ✅  Chrome installation found
+      ⚠️   GitHub token not set
+      Healthcheck passed!
+
+      Automatically determined ./build as \`staticDistDir\`.
+      Set it explicitly in lighthouserc.json if incorrect.
+
+      Started a web server on port XXXX...
+      Running Lighthouse 1 time(s) on http://localhost:XXXX/bad.html
+      Run #1...done.
+      Running Lighthouse 1 time(s) on http://localhost:XXXX/good.html
+      Run #1...done.
+      Done running Lighthouse!
+
+
+      Uploading median LHR of http://localhost:XXXX/bad.html...success!
+      Open the report at https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/XXXX-XXXX.report.html
+      Uploading median LHR of http://localhost:XXXX/good.html...success!
+      Open the report at https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/XXXX-XXXX.report.html
+      GitHub token found, attempting to set status...
+      {
+        state: 'failure',
+        context: 'lhci/url/bad.html',
+        description: 'Failed 1 assertion(s)',
+        target_url: 'https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/XXXX-XXXX.report.html'
+      }
+      GitHub responded with 401
+      {\\"message\\":\\"Bad credentials\\",\\"documentation_url\\":\\"https://docs.github.com/rest\\"}
+
+      {
+        state: 'failure',
+        context: 'lhci/url/good.html',
+        description: 'Failed 1 assertion(s)',
+        target_url: 'https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/XXXX-XXXX.report.html'
+      }
+      GitHub responded with 401
+      {\\"message\\":\\"Bad credentials\\",\\"documentation_url\\":\\"https://docs.github.com/rest\\"}
+
+
+      "
+    `);
+    expect(stderr).toMatchInlineSnapshot(`
+      "Checking assertions against 2 URL(s), 2 total run(s)
+
+      1 result(s) for [1mhttp://localhost:XXXX/bad.html[0m :
+
+        [31mX[0m  [1mviewport[0m failure for [1mminScore[0m assertion
+             Does not have a \`<meta name=\\"viewport\\">\` tag with \`width\` or \`initial-scale\`
+             https://web.dev/viewport/
+
+              expected: >=[32m0.9[0m
+                 found: [31m0[0m
+            [2mall values: 0[0m
+
+      1 result(s) for [1mhttp://localhost:XXXX/good.html[0m :
+
+        ✅  [1mviewport[0m passing for [1mminScore[0m assertion
+             Has a \`<meta name=\\"viewport\\">\` tag with \`width\` or \`initial-scale\`
+             https://web.dev/viewport/
+
+              expected: >=[32m0.9[0m
+                 found: [32m1[0m
+            [2mall values: 1[0m
+
+      Assertion failed. Exiting with status code 1.
+      assert command failed. Exiting with status code 1.
+      "
+    `);
+    expect(status).toEqual(1);
+  }, 180000);
+});

--- a/packages/cli/test/fixtures/autorun-github/build/bad.html
+++ b/packages/cli/test/fixtures/autorun-github/build/bad.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>bad test page for autorun usage</title>
+  </head>
+  <body>
+    test
+  </body>
+</html>

--- a/packages/cli/test/fixtures/autorun-github/build/good.html
+++ b/packages/cli/test/fixtures/autorun-github/build/good.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>good test page for autorun usage</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    test
+  </body>
+</html>

--- a/packages/cli/test/fixtures/autorun-github/lighthouserc.json
+++ b/packages/cli/test/fixtures/autorun-github/lighthouserc.json
@@ -1,0 +1,20 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 1
+    },
+    "assert": {
+      "assertMatrix": [
+        {
+          "assertions": {
+            "viewport": "error"
+          }
+        }
+      ],
+      "includePassedAssertions": true
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
This issue happens when `includePassedAssertions` is set as `true`.

The first commit shows the error as the test was written before the fix.

Relates to issue #570
Inspired by #571