### PR TITLE
reference node 12 as supported version

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,10 +85,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 10.x
+      - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - name: npm install, build
         run: |
           npm install


### PR DESCRIPTION
Users copy-pasting the existing starting template will run into issues such as https://github.com/GoogleChrome/lighthouse/issues/11953, since lighthouse CI will not work with node 10. 