### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -132,7 +132,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/node:10.16-browsers
+      - image: circleci/node:15.12-browsers
     working_directory: ~/your-project
     steps:
       - checkout


### PR DESCRIPTION
updated instructions for circleci. Changed required node image from 10.16 to 15.16 (required node version for lighthouse >12)