### PR TITLE
feat(server): enable passing of server host

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -887,6 +887,10 @@ Options:
 #### `port`
 
 The port for the server to listen on. A value of `0` will use a random available port.
+https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback
+#### `host`
+
+The host to bind the server to. The [default](https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback) is to use the [unspecified IPv6 address](https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address) (::) when IPv6 is available, or the [unspecified IPv4 address](https://en.wikipedia.org/wiki/0.0.0.0) (0.0.0.0) otherwise. To only accept connections on IPv4 use `0.0.0.0` as host.
 
 #### `storage`
 

--- a/packages/cli/src/server/server.js
+++ b/packages/cli/src/server/server.js
@@ -23,6 +23,9 @@ function buildCommand(yargs) {
       type: 'number',
       default: 9001,
     },
+    listenHost: {
+      type: 'string',
+    },
     'storage.storageMethod': {
       type: 'string',
       choices: ['sql', 'spanner'],

--- a/packages/cli/src/server/server.js
+++ b/packages/cli/src/server/server.js
@@ -23,7 +23,7 @@ function buildCommand(yargs) {
       type: 'number',
       default: 9001,
     },
-    listenHost: {
+    host: {
       type: 'string',
     },
     'storage.storageMethod': {

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -94,7 +94,12 @@ async function createServer(options) {
 
     server.on('error', err => reject(err));
 
-    server.listen(options.port, () => {
+    const listenOptions = {
+      port: options.port,
+      host: options.listenHost,
+    };
+
+    server.listen(listenOptions, () => {
       const serverAddress = server.address();
       const listenPort =
         typeof serverAddress === 'string' || !serverAddress ? options.port : serverAddress.port;

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -96,7 +96,7 @@ async function createServer(options) {
 
     const listenOptions = {
       port: options.port,
-      host: options.listenHost,
+      host: options.host,
     };
 
     server.listen(listenOptions, () => {

--- a/types/server.d.ts
+++ b/types/server.d.ts
@@ -178,6 +178,7 @@ declare global {
       export interface Options {
         logLevel: 'silent' | 'verbose';
         port: number;
+        listenHost?: string
         storage: StorageOptions;
         psiCollectCron?: {
           psiApiKey: string;

--- a/types/server.d.ts
+++ b/types/server.d.ts
@@ -178,7 +178,7 @@ declare global {
       export interface Options {
         logLevel: 'silent' | 'verbose';
         port: number;
-        listenHost?: string
+        host?: string
         storage: StorageOptions;
         psiCollectCron?: {
           psiApiKey: string;


### PR DESCRIPTION
This PR adds the ability to pass a listening host to the Lighthouse CI server.
This makes it possible to let it bind to localhost or IPv4 with `0.0.0.0`.

**Background**
We want to run the docker image in our Kubernetes cluster. 
So we create a deployment with the `patrickhulce/lhci-server` image.
When accessing the server via the nginx ingress we keep getting a http 503 error.
After investigation the problem seems to be that the service is listening on IPv6 instead of IPv4.
So if we could pass it a IPv4 listenhost of `0.0.0.0` the server will use IPv4 instead of IPv6 and the problem will be solved.

Output netstat:
```
root@lhci-server-7fdf98f947-l8dwg:/usr/src/lhci# apt-get update && apt install -y net-tools
root@lhci-server-7fdf98f947-l8dwg:/usr/src/lhci# netstat -tulpn | grep LISTEN
tcp6       0      0 :::9001                 :::*                    LISTEN      25/node
```
