### PR TITLE
docs(jenkins): update Node version to 12 for setup script

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -195,7 +195,7 @@ echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sud
 wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
 
 # Add Node's apt-key
-curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 
 # Install NodeJS and Google Chrome
 sudo apt-get update


### PR DESCRIPTION
Previous setup script referenced Node 10 which will fail to run with the latest version of `@lhci/cli`.

This is a quick update for those who may also run across this :+1: 

fixes #591