### PR TITLE
docs(server): SQL SSL docs update on using ssl with no custom cert

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1307,6 +1307,10 @@ module.exports = {
         sqlDialect: 'postgres',
         sqlConnectionSsl: true,
         sqlConnectionUrl: process.env.DATABASE_URL,
+        sqlDialectOptions: {
+          // this flag also needs to be set in order to make a secure connection if not setting custom certificates
+          ssl: true,
+        },
         sequelizeOptions: {
           pool: {
             acquire: 30000,
@@ -1349,6 +1353,9 @@ module.exports = {
         sqlDialect: 'postgres',
         sqlConnectionSsl: true,
         sqlConnectionUrl: process.env.DATABASE_URL,
+        sqlDialectOptions: {
+          ssl: true,
+        },
         sequelizeOptions: {
           pool: {
             acquire: 30000,


### PR DESCRIPTION
Found out that when using certificates defined else where you need to specify in the `sqlDialectOptions` that ssl is true.

Related thread - https://github.com/sequelize/sequelize/issues/956#issuecomment-147745033

Just felt it should be noted in the docs.

I suppose the alternative is to bind `sqlConnectionSsl: true` to map to
```
dialectOptions: {
  ssl: true,
}
```
Without this the API returns:

```
SequelizeConnectionError: no pg_hba.conf entry for host "172.18.48.124", user "lighthouseci", database "lighthouseci", SSL off
    at /usr/src/lhci/node_modules/sequelize/lib/dialects/postgres/connection-manager.js:154:24
    at Connection.connectingErrorHandler (/usr/src/lhci/node_modules/pg/lib/client.js:194:14)
    at Connection.emit (events.js:315:20)
    at Socket.<anonymous> (/usr/src/lhci/node_modules/pg/lib/connection.js:134:12)
    at Socket.emit (events.js:315:20)
    at addChunk (_stream_readable.js:295:12)
    at readableAddChunk (_stream_readable.js:271:9)
    at Socket.Readable.push (_stream_readable.js:212:10)
    at TCP.onStreamRead (internal/stream_base_commons.js:186:23)
```