### PR TITLE
Update debug messages when checking hash uniqueness

### DIFF
--- a/packages/cli/src/healthcheck/healthcheck.js
+++ b/packages/cli/src/healthcheck/healthcheck.js
@@ -124,8 +124,8 @@ const checks = [
   },
   {
     id: 'lhciServer',
-    label: 'LHCI server unique build for this hash',
-    failureLabel: 'LHCI server non-unique build for this hash',
+    label: 'LHCI server can accept a build for this commit hash',
+    failureLabel: 'LHCI server already has a build for this commit hash',
     // the test only makes sense if they've configured an LHCI server
     shouldTest: opts => Boolean(opts.serverBaseUrl && opts.token),
     test: async opts => {

--- a/packages/cli/test/autorun-start-server.test.js
+++ b/packages/cli/test/autorun-start-server.test.js
@@ -105,7 +105,7 @@ describe('Lighthouse CI autorun CLI with startServerCommand', () => {
       ✅  LHCI server reachable
       ✅  LHCI server API-compatible
       ✅  LHCI server token valid
-      ✅  LHCI server unique build for this hash
+      ✅  LHCI server can accept a build for this commit hash
       Healthcheck passed!
 
       Started a web server with \\"node autorun-server.js\\"...

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -134,7 +134,7 @@ describe('Lighthouse CI CLI', () => {
         ✅  LHCI server reachable
         ✅  LHCI server API-compatible
         ✅  LHCI server token valid
-        ✅  LHCI server unique build for this hash
+        ✅  LHCI server can accept a build for this commit hash
         Healthcheck passed!
         "
       `);
@@ -159,7 +159,7 @@ describe('Lighthouse CI CLI', () => {
         ✅  LHCI server reachable
         ✅  LHCI server API-compatible
         ✅  LHCI server token valid
-        ✅  LHCI server unique build for this hash
+        ✅  LHCI server can accept a build for this commit hash
         Healthcheck failed!
         "
       `);


### PR DESCRIPTION
Based on the thread in the attached ticket, I've clarified the debug messages when LHCI checks commit hash uniqueness.

Close #612 