### PR TITLE
fix(cli): lhci open to process multiple urls

### DIFF
--- a/packages/cli/src/open/open.js
+++ b/packages/cli/src/open/open.js
@@ -39,7 +39,7 @@ async function runCommand(options) {
   }
 
   for (const lhr of representativeLhrs) {
-    if (options.url && (lhr.finalUrl !== options.url && !options.url.some(item => lhr.finalUrl.includes(item)))) continue;
+    if (targetUrls.size && !targetUrls.has(lhr.finalUrl)) continue;
 
     process.stdout.write(`Opening median report for ${lhr.finalUrl}...\n`);
     const tmpFile = tmp.fileSync({postfix: '.html'});

--- a/packages/cli/src/open/open.js
+++ b/packages/cli/src/open/open.js
@@ -37,6 +37,8 @@ async function runCommand(options) {
   if (!representativeLhrs.length) {
     process.stdout.write('No available reports to open. ');
   }
+  
+  const targetUrls = new Set([].concat(options.url || []));
 
   for (const lhr of representativeLhrs) {
     if (targetUrls.size && !targetUrls.has(lhr.finalUrl)) continue;

--- a/packages/cli/src/open/open.js
+++ b/packages/cli/src/open/open.js
@@ -43,7 +43,7 @@ async function runCommand(options) {
     (options.url || []);
 
   for (const lhr of representativeLhrs) {
-    if (targetUrls.size && !targetUrls.has(lhr.finalUrl)) continue;
+    if (targetUrls.length && !targetUrls.includes(lhr.finalUrl)) continue;
 
     process.stdout.write(`Opening median report for ${lhr.finalUrl}...\n`);
     const tmpFile = tmp.fileSync({postfix: '.html'});

--- a/packages/cli/src/open/open.js
+++ b/packages/cli/src/open/open.js
@@ -38,7 +38,9 @@ async function runCommand(options) {
     process.stdout.write('No available reports to open. ');
   }
   
-  const targetUrls = new Set([].concat(options.url || []));
+  const targetUrls = typeof options.url === 'string' ? 
+    [options.url] : 
+    (options.url || []);
 
   for (const lhr of representativeLhrs) {
     if (targetUrls.size && !targetUrls.has(lhr.finalUrl)) continue;

--- a/packages/cli/src/open/open.js
+++ b/packages/cli/src/open/open.js
@@ -39,7 +39,7 @@ async function runCommand(options) {
   }
 
   for (const lhr of representativeLhrs) {
-    if (options.url && lhr.finalUrl !== options.url) continue;
+    if (options.url && (lhr.finalUrl !== options.url && !options.url.some(item => lhr.finalUrl.includes(item)))) continue;
 
     process.stdout.write(`Opening median report for ${lhr.finalUrl}...\n`);
     const tmpFile = tmp.fileSync({postfix: '.html'});

--- a/packages/cli/src/open/open.js
+++ b/packages/cli/src/open/open.js
@@ -37,10 +37,8 @@ async function runCommand(options) {
   if (!representativeLhrs.length) {
     process.stdout.write('No available reports to open. ');
   }
-  
-  const targetUrls = typeof options.url === 'string' ? 
-    [options.url] : 
-    (options.url || []);
+
+  const targetUrls = typeof options.url === 'string' ? [options.url] : options.url || [];
 
   for (const lhr of representativeLhrs) {
     if (targetUrls.length && !targetUrls.includes(lhr.finalUrl)) continue;


### PR DESCRIPTION
### Description
- `lhci open` command currently silently fails if configuration `ci.collect.url` is an array of URLs (valid) rather than a string

### To reproduce
1. Set configuration:
  ```
  ci: {
    collect: {
      url: [
        'https://www.google.com/',
        'https://www.google.de/'
      ]
    }
  }
  ```
2. Run `lhci collect` to generate reports successfully
3. Run `lhci open`. No URL opened in browser (due to `continue`) but `Done!` message still printed to console