### PR TITLE
feat(cli): add psi strategy in option for psi runner, keeping mobile …

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -218,6 +218,7 @@ Options:
   --puppeteerLaunchOptions   The object of puppeteer launch options
   --psiApiKey                [psi only] The API key to use for PageSpeed Insights runner method.
                              You do not need to use this unless you wrote a custom version.
+  --psiStrategy              [psi only] The strategy to use for PageSpeed Insights runner method. Use mobile or desktop. The                                default value is mobile
   --startServerCommand       The command to run to start the server.
   --startServerReadyPattern  String pattern to listen for started server.
                                                                   [string] [default: "listen|ready"]
@@ -337,6 +338,12 @@ The API key to use for making PageSpeed Insights requests. Required if using `me
 _method=psi only_
 
 The API endpoint to hit for making a PageSpeed Insights request. It is very unlikely you should need to use this option. Only use this if you have self-hosted a custom version of the PSI API.
+
+#### `psiStrategy`
+
+_method=psi only_
+
+Use this option to change the strategy to use for PageSpeed Insights runner method. Use `mobile` or `desktop`. The default value is `mobile`.
 
 #### `startServerCommand`
 

--- a/packages/cli/src/collect/collect.js
+++ b/packages/cli/src/collect/collect.js
@@ -46,6 +46,10 @@ function buildCommand(yargs) {
     psiApiKey: {
       description: '[psi only] The API key to use for PageSpeed Insights runner method.',
     },
+    psiStrategy: {
+      description:
+        '[psi only] The strategy to use for PageSpeed Insights runner method. Use mobile or desktop. The default value is mobile',
+    },
     staticDistDir: {
       description: 'The build directory where your HTML files to run Lighthouse on are located.',
     },

--- a/packages/cli/src/collect/psi-runner.js
+++ b/packages/cli/src/collect/psi-runner.js
@@ -17,7 +17,7 @@ class PsiRunner {
     const apiKey = options.psiApiKey;
     if (!apiKey) throw new Error('PSI API key must be provided to use the PSI runner');
     const client = new PsiClient({apiKey, endpointURL: options.psiApiEndpoint});
-    return JSON.stringify(await client.run(url));
+    return JSON.stringify(await client.run(url, {strategy: options.psiStrategy}));
   }
 
   /**

--- a/packages/utils/src/psi-runner.js
+++ b/packages/utils/src/psi-runner.js
@@ -19,7 +19,7 @@ class PsiRunner {
 
   /**
    * @param {string} url
-   * @param {{psiApiKey?: string, psiApiEndpoint?: string}} [options]
+   * @param {{psiApiKey?: string, psiApiEndpoint?: string, psiStrategy?: 'mobile'|'desktop'}} [options]
    * @return {Promise<string>}
    */
   async run(url, options) {
@@ -27,7 +27,7 @@ class PsiRunner {
     const apiKey = options.psiApiKey;
     if (!apiKey) throw new Error('PSI API key must be provided to use the PSI runner');
     const client = new PsiClient({apiKey, endpointURL: options.psiApiEndpoint});
-    return JSON.stringify(await client.run(url));
+    return JSON.stringify(await client.run(url, {strategy: options.psiStrategy}));
   }
 
   /**

--- a/types/collect.d.ts
+++ b/types/collect.d.ts
@@ -47,6 +47,7 @@ declare global {
         autodiscoverUrlBlocklist?: string | string[];
         psiApiKey?: string;
         psiApiEndpoint?: string;
+        psiStrategy?: 'mobile'|'desktop';
         staticDistDir?: string;
         isSinglePageApplication?: boolean;
         startServerCommand?: string;


### PR DESCRIPTION
Hi, i need to use mobile and desktop strategy for psi.

So, i add option for lhci collect.

use:

lhci collect --psiStrategy='mobile'
lhci collect --psiStrategy='desktop'