### PR TITLE
update cli version to 0.8 in docs

### DIFF
--- a/docs/complex-setup.md
+++ b/docs/complex-setup.md
@@ -24,7 +24,7 @@ fi
 
 npm run deploy
 
-npm install -g @lhci/cli@0.7.x
+npm install -g @lhci/cli@0.8.x
 lhci healthcheck --fatal
 lhci collect --url=http://localhost:9000/index.html
 lhci assert --preset="lighthouse:recommended"
@@ -121,7 +121,7 @@ Now that we have our environment ready, time to run Lighthouse CI. The `collect`
 
 # Install Lighthouse CI
 # If you're already using node to manage your project, add it to your package.json `devDependencies` instead to skip this step.
-npm install -g @lhci/cli@0.7.x
+npm install -g @lhci/cli@0.8.x
 
 # Run a healthcheck to make sure everything looks good before we run collection.
 lhci healthcheck --fatal

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -95,7 +95,7 @@ jobs:
           npm run build
       - name: run Lighthouse CI
         run: |
-          npm install -g @lhci/cli@0.7.x
+          npm install -g @lhci/cli@0.8.x
           lhci autorun
 ```
 
@@ -113,7 +113,7 @@ node_js: v12
 addons:
   chrome: stable
 before_install:
-  - npm install -g @lhci/cli@0.7.x
+  - npm install -g @lhci/cli@0.8.x
 script:
   - npm run build
   - lhci autorun
@@ -138,7 +138,7 @@ jobs:
       - checkout
       - run: npm install
       - run: npm run build
-      - run: sudo npm install -g @lhci/cli@0.7.x
+      - run: sudo npm install -g @lhci/cli@0.8.x
       - run: lhci autorun
 ```
 
@@ -173,7 +173,7 @@ lhci:
   script:
     - npm install
     - npm run build
-    - npm install -g @lhci/cli@0.7.x
+    - npm install -g @lhci/cli@0.8.x
     - lhci autorun --upload.target=temporary-public-storage --collect.settings.chromeFlags="--no-sandbox" || echo "LHCI failed!"
 ```
 
@@ -215,7 +215,7 @@ npm run build
 export CHROME_PATH=$(which google-chrome-stable)
 export LHCI_BUILD_CONTEXT__EXTERNAL_BUILD_URL="$BUILD_URL"
 
-npm install -g @lhci/cli@0.7.x
+npm install -g @lhci/cli@0.8.x
 lhci autorun
 ```
 
@@ -264,7 +264,7 @@ steps:
     waitFor: ['build']
     name: cypress/browsers:node14.15.0-chrome86-ff82
     entrypoint: '/bin/sh'
-    args: ['-c', 'npm install -g @lhci/cli@0.7.x && lhci autorun --failOnUploadFailure']
+    args: ['-c', 'npm install -g @lhci/cli@0.8.x && lhci autorun --failOnUploadFailure']
     env:
       - 'LHCI_BUILD_CONTEXT__CURRENT_BRANCH=$BRANCH_NAME'
 
@@ -370,7 +370,7 @@ jobs:
           npm run build
       - name: run Lighthouse CI
         run: |
-          npm install -g @lhci/cli@0.7.x
+          npm install -g @lhci/cli@0.8.x
           lhci autorun
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
@@ -468,7 +468,7 @@ Once the server is set up, _on your local laptop or desktop_, make sure you can 
 ```bash
 $ curl https://your-lhci-server.example.com/version # Make sure you can connect to your server.
 0.x.x
-$ npm install -g @lhci/cli@0.7.x # Install the Lighthouse CI CLI.
+$ npm install -g @lhci/cli@0.8.x # Install the Lighthouse CI CLI.
 Installing...
 $ lhci wizard # Use the wizard to create a project.
 ? Which wizard do you want to run? new-project

--- a/docs/server.md
+++ b/docs/server.md
@@ -133,7 +133,3 @@ const lhci = require('@lhci/server');
 ### Firewall Rules
 
 You can also protect your server through firewall rules to prevent it from being accessed from outside your internal network. Refer to your infrastructure provider's documentation on how to setup firewall rules to block external IP addresses from accessing the server. Don't forget to allow your CI machines!
-
-```
-
-```


### PR DESCRIPTION
While doing the first time set-up I noticed that the getting started docs are not up-to date with the current CLI version so I updated all `npm install` commands to 0.8.

Also I noticed that the migration guide doesn't include guidance on 0.7 to 0.8 yet. Maybe you can add those?