### PR TITLE
Updates to support closed network

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,8 +20,6 @@
     "start:storybook": "start-storybook -p 6006 --no-dll"
   },
   "dependencies": {
-    "@fontsource/material-icons": "^4.4.5",
-    "@fontsource/roboto": "^4.4.5",
     "@lhci/utils": "0.1.0",
     "bluebird": "^3.7.2",
     "body-parser": "^1.18.3",
@@ -43,7 +41,10 @@
     "plotly.js": "^1.48.3",
     "preact": "^10.0.1",
     "preact-async-route": "^2.2.1",
-    "preact-router": "^3.1.0"
+    "preact-router": "^3.1.0",
+    "@fontsource/material-icons": "^4.4.5",
+    "@fontsource/roboto": "^4.4.5",
+    "@fontsource/roboto-mono": "^4.4.5"
   },
   "alias": {
     "isomorphic-fetch": "clsx"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,6 +20,8 @@
     "start:storybook": "start-storybook -p 6006 --no-dll"
   },
   "dependencies": {
+    "@fontsource/material-icons": "^4.4.5",
+    "@fontsource/roboto": "^4.4.5",
     "@lhci/utils": "0.1.0",
     "bluebird": "^3.7.2",
     "body-parser": "^1.18.3",

--- a/packages/server/src/ui/components/lhr-viewer-link.jsx
+++ b/packages/server/src/ui/components/lhr-viewer-link.jsx
@@ -13,7 +13,8 @@ import './lhr-viewer-link.css';
 
 /** @param {LH.Result} lhr */
 export function openLhrInClassicViewer(lhr) {
-  const VIEWER_ORIGIN = 'https://googlechrome.github.io';
+  // Allows for self-hosted viewer uri instead of linking externally
+  const VIEWER_ORIGIN = process.env.VIEWER_ORIGIN != null ? process.env.VIEWER_ORIGIN : 'https://googlechrome.github.io';
   // Chrome doesn't allow us to immediately postMessage to a popup right
   // after it's created. Normally, we could also listen for the popup window's
   // load event, however it is cross-domain and won't fire. Instead, listen

--- a/packages/server/src/ui/components/lhr-viewer-link.jsx
+++ b/packages/server/src/ui/components/lhr-viewer-link.jsx
@@ -14,7 +14,7 @@ import './lhr-viewer-link.css';
 /** @param {LH.Result} lhr */
 export function openLhrInClassicViewer(lhr) {
   // Allows for self-hosted viewer uri instead of linking externally
-  const VIEWER_ORIGIN = process.env.VIEWER_ORIGIN != null ? process.env.VIEWER_ORIGIN : 'https://googlechrome.github.io';
+  const VIEWER_ORIGIN = process.env.VIEWER_ORIGIN || 'https://googlechrome.github.io';
   // Chrome doesn't allow us to immediately postMessage to a popup right
   // after it's created. Normally, we could also listen for the popup window's
   // load event, however it is cross-domain and won't fire. Instead, listen

--- a/packages/server/src/ui/entry.jsx
+++ b/packages/server/src/ui/entry.jsx
@@ -8,11 +8,11 @@ import {h, render} from 'preact';
 import {App} from './app.jsx';
 
 // Fontsource for fonts/icons instead of google cdn
-import "@fontsource/roboto/400.css";
-import "@fontsource/roboto/500.css";
-import "@fontsource/roboto-mono/400.css";
-import "@fontsource/roboto-mono/500.css";
-import "@fontsource/material-icons";
+import '@fontsource/roboto/400.css';
+import '@fontsource/roboto/500.css';
+import '@fontsource/roboto-mono/400.css';
+import '@fontsource/roboto-mono/500.css';
+import '@fontsource/material-icons';
 
 const preactRoot = document.getElementById('preact-root');
 if (!preactRoot) throw new Error('Missing #preact-root');

--- a/packages/server/src/ui/entry.jsx
+++ b/packages/server/src/ui/entry.jsx
@@ -10,6 +10,8 @@ import {App} from './app.jsx';
 // Fontsource for fonts/icons instead of google cdn
 import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/500.css";
+import "@fontsource/roboto-mono/400.css";
+import "@fontsource/roboto-mono/500.css";
 import "@fontsource/material-icons";
 
 const preactRoot = document.getElementById('preact-root');

--- a/packages/server/src/ui/entry.jsx
+++ b/packages/server/src/ui/entry.jsx
@@ -7,6 +7,11 @@
 import {h, render} from 'preact';
 import {App} from './app.jsx';
 
+// Fontsource for fonts/icons instead of google cdn
+import "@fontsource/roboto/400.css";
+import "@fontsource/roboto/500.css";
+import "@fontsource/material-icons";
+
 const preactRoot = document.getElementById('preact-root');
 if (!preactRoot) throw new Error('Missing #preact-root');
 render(<App />, preactRoot);

--- a/packages/server/src/ui/index.html
+++ b/packages/server/src/ui/index.html
@@ -4,18 +4,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Historical results and diff viewer for Lighthouse CI." />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Roboto:400,500&display=swap"
-    />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Roboto+Mono:400,500&display=swap"
-    />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/icon?family=Material+Icons&display=block"
-    />
     <link rel="icon" href="./favicon.png" />
     <title>Lighthouse CI | Dashboard</title>
   </head>

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -17,14 +17,12 @@
   },
   "devDependencies": {
     "clsx": "^1.0.4",
-    "preact": "^10.0.1"
-  },
-  "alias": {
-    "isomorphic-fetch": "clsx"
-  },
-  "dependencies": {
+    "preact": "^10.0.1",
     "@fontsource/material-icons": "^4.4.5",
     "@fontsource/roboto": "^4.4.5",
     "@fontsource/roboto-mono": "^4.4.5"
+  },
+  "alias": {
+    "isomorphic-fetch": "clsx"
   }
 }

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -21,5 +21,10 @@
   },
   "alias": {
     "isomorphic-fetch": "clsx"
+  },
+  "dependencies": {
+    "@fontsource/material-icons": "^4.4.5",
+    "@fontsource/roboto": "^4.4.5",
+    "@fontsource/roboto-mono": "^4.4.5"
   }
 }

--- a/packages/viewer/src/ui/entry.jsx
+++ b/packages/viewer/src/ui/entry.jsx
@@ -8,11 +8,11 @@ import {h, render} from 'preact';
 import {App} from './app.jsx';
 
 // Fontsource for fonts/icons instead of google cdn
-import "@fontsource/roboto/400.css";
-import "@fontsource/roboto/500.css";
-import "@fontsource/roboto-mono/400.css";
-import "@fontsource/roboto-mono/500.css";
-import "@fontsource/material-icons";
+import '@fontsource/roboto/400.css';
+import '@fontsource/roboto/500.css';
+import '@fontsource/roboto-mono/400.css';
+import '@fontsource/roboto-mono/500.css';
+import '@fontsource/material-icons';
 
 const preactRoot = document.getElementById('preact-root');
 if (!preactRoot) throw new Error('Missing #preact-root');

--- a/packages/viewer/src/ui/entry.jsx
+++ b/packages/viewer/src/ui/entry.jsx
@@ -7,6 +7,13 @@
 import {h, render} from 'preact';
 import {App} from './app.jsx';
 
+// Fontsource for fonts/icons instead of google cdn
+import "@fontsource/roboto/400.css";
+import "@fontsource/roboto/500.css";
+import "@fontsource/roboto-mono/400.css";
+import "@fontsource/roboto-mono/500.css";
+import "@fontsource/material-icons";
+
 const preactRoot = document.getElementById('preact-root');
 if (!preactRoot) throw new Error('Missing #preact-root');
 render(<App />, preactRoot);

--- a/packages/viewer/src/ui/index.html
+++ b/packages/viewer/src/ui/index.html
@@ -8,15 +8,6 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Roboto:400,500&display=swap"
-    />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/icon?family=Roboto+Mono:400,500&display=swap"
-    />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link rel="icon" href="../../../server/src/ui/favicon.png" />
     <title>Lighthouse CI | Viewer</title>
   </head>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2071,6 +2071,21 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@fontsource/material-icons@^4.4.5":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@fontsource/material-icons/-/material-icons-4.4.5.tgz#12afd469186382b4f08684927c7b75e47559ae6c"
+  integrity sha512-/J1UhmwLkcHjXvRAH63/pghttPJQwq6hZ11fCNv7syS5Ym5saTV3fm6J5SyoPJ/+s0HcNyiddGmcAOOVrBkIGA==
+
+"@fontsource/roboto-mono@^4.4.5":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@fontsource/roboto-mono/-/roboto-mono-4.4.5.tgz#63c54719a8d592d793632501a56d570572c17065"
+  integrity sha512-y9fbKH1eCCkcqtRGhevFlmR5schCRz1GiTT/VYz6z8Ij0WHW0tS26BhMyXhmSgEIiFt+254yS8teqP+cc7Xq0w==
+
+"@fontsource/roboto@^4.4.5":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-4.4.5.tgz#9ef1b9288ac4a97b97906da920c63c08dba97c89"
+  integrity sha512-e3s7BF8MDBLpkA2r6lnl5PMnllF0McVvpolK9h2zzvVJw2WPexP1GTgMKHISlglYZRij2lKg/ZjQcIUUYDsAXg==
+
 "@iarna/toml@^2.2.0":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.3.tgz#f060bf6eaafae4d56a7dac618980838b0696e2ab"


### PR DESCRIPTION
As discussed in https://github.com/GoogleChrome/lighthouse-ci/discussions/635 - this provides two relatively simple changes:

- Makes use of fontsource to pull in roboto, roboto-mono, and material icons instead of using the googleapis font CDN (without use of a proxy these lead to rendering issues on the server-ui and viewer)
- An optional use of $VIEWER_ORIGIN environment variable to configure a self-hosted [viewer](https://github.com/GoogleChrome/lighthouse/tree/master/lighthouse-viewer) instead of linking to the public internet copy on github


As I mentioned in the discussion, I have relatively little UI experience and if there's a better way to accomplish these localizations I'm open to learning other options. I think the alternative I was finding a lot of while googling was using something like webpack to produce the public.html for the font scripts if we wanted this to be optional.

Finally, I think both of these changes were relatively trivial but if a test is wanted I could look into learning some jest. Thanks!

(re-created PR with fixed git history for the bot)