### PR TITLE
Add additional troubleshooting entry for Ancestor hash not determinable

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -77,3 +77,29 @@ Different environments and ways of running Lighthouse will tend to see different
 - Geographic location
 
 The team does not have the bandwidth to assist with debugging this problem. Please do _not_ file an issue about it if you're unable to get scores from different environments to match.
+
+## Running LHCI in Github Actions I constantly get Ancestor hash not determinable
+
+If you are using `actions/checkout@v2` to checkout your repository and based on the size and traffic on your repo this error might happen due to how he checkout action is configured and is not a LHCI issue.
+
+Checkout action by default doesn't clone the entire repo and the number of commits to fetch is set to 1 for performance reasons. When LHCI runs the health check the ancestor hash might be missing because the branch / hash is not there in the local history.
+
+In order to fix it change / add the following:
+
+```yml
+name: Run Lighthouse tests
+jobs:
+  lhci:
+    name: Lighthouse
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 20
+      - name: Fetch base_ref HEAD to use it as Ancestor hash in LHCI
+        run: git fetch --depth=1 origin +refs/heads/${{github.base_ref}}:refs/remotes/origin/${{github.base_ref}}
+```
+
+The additions are `fetch-depth: 20` added to `actions/checkout@v2` and a new step to fetch base_ref HEAD to use it as ancestor hash in LHCI.
+
+The fetch depth set to 20 is a good default, but might not work in all cases, you can adjut it based on your needs.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -102,4 +102,4 @@ jobs:
 
 The additions are `fetch-depth: 20` added to `actions/checkout@v2` and a new step to fetch base_ref HEAD to use it as ancestor hash in LHCI.
 
-The fetch depth set to 20 is a good default, but might not work in all cases, you can adjut it based on your needs.
+The fetch depth set to 20 is a good default, but might not work in all cases, you can adjust it based on your needs.


### PR DESCRIPTION
When running LHCI in GH Actions due to how checkout action clones the repo with a fetch depth of 1 by default the base branch might be missing so LH will not be able to find it during health check.

Changing the action settings and fetching the base using a new step will fix this problem for almost all cases where the repo is big enough.

This has been discussed here https://github.com/actions/checkout/issues/93 and here https://github.com/actions/checkout/pull/213