### PR TITLE
feat: support cjs config file extension

### DIFF
--- a/packages/utils/src/lighthouserc.js
+++ b/packages/utils/src/lighthouserc.js
@@ -11,6 +11,8 @@ const yaml = require('js-yaml');
 const _ = require('./lodash.js');
 
 const RC_FILE_NAMES = [
+  '.lighthouserc.cjs',
+  'lighthouserc.cjs',
   '.lighthouserc.js',
   'lighthouserc.js',
   '.lighthouserc.json',
@@ -21,7 +23,7 @@ const RC_FILE_NAMES = [
   'lighthouserc.yaml',
 ];
 
-const JS_FILE_EXTENSION_REGEX = /\.(js)$/i;
+const JS_FILE_EXTENSION_REGEX = /\.(cjs|js)$/i;
 const YAML_FILE_EXTENSION_REGEX = /\.(yml|yaml)$/i;
 
 /**

--- a/packages/utils/test/lighthouserc.test.js
+++ b/packages/utils/test/lighthouserc.test.js
@@ -232,6 +232,12 @@ describe('lighthouserc.js', () => {
         tempFile = null;
       });
 
+      it('.cjs', () => {
+        tempFile = path.join(tempDir, 'lighthouserc.cjs');
+        writeJsFile(tempFile, {});
+        expect(rc.findRcFile(tempDir)).toEqual(tempFile);
+      });
+
       it('.js', () => {
         tempFile = path.join(tempDir, 'lighthouserc.js');
         writeJsFile(tempFile, {});


### PR DESCRIPTION
This allows users to use Lighthouse CI in a project which has `"type": "module"` in their `package.json` file.

I also looked into supporting ESM configuration files, but since `import()` is asynchronous, this is a lot more work than just supporting `.cjs` files in a code base I’m not very familiar with.