### PR TITLE
docs: update readme to use 0.8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
-      - run: npm install && npm install -g @lhci/cli@0.7.x
+      - run: npm install && npm install -g @lhci/cli@0.8.x
       - run: npm run build
       - run: lhci autorun
 ```


### PR DESCRIPTION
The latest release of Lighthouse is not reflected in the `Getting started` section of the README. This change updates the version.