### PR TITLE
Specify node.js version in Github Actions example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
+        with:
+          node-version: 14
       - run: npm install && npm install -g @lhci/cli@0.8.x
       - run: npm run build
       - run: lhci autorun


### PR DESCRIPTION
Specify node.js version for `actions/setup-node@v1` step in example Github Actions code. Without this, the snippet [currently fails](https://gist.github.com/j0nas/06fc18b10d74d9b8ca3ad8f0db9cac74) as it defaults to an earlier version of node.js which raises a SyntaxError for the current version of the module.

