### PR TITLE
Add LCP, TBT and FID to Distribution Graph

### DIFF
--- a/packages/server/src/ui/routes/project-dashboard/category-card.jsx
+++ b/packages/server/src/ui/routes/project-dashboard/category-card.jsx
@@ -129,16 +129,34 @@ const MetricDistributionGraphs = props => {
         scoreLevels={SCORE_LEVEL_METRIC_THRESHOLDS['first-contentful-paint']}
       />
       <MetricDistributionGraph
-        abbreviation={'SI'}
-        label={'Speed Index'}
-        statistics={stats('audit_speed-index_median')}
-        scoreLevels={SCORE_LEVEL_METRIC_THRESHOLDS['speed-index']}
+        abbreviation={'LCP'}
+        label={'First Contentful Paint'}
+        statistics={stats('audit_largest-contentful-paint_median')}
+        scoreLevels={SCORE_LEVEL_METRIC_THRESHOLDS['largest-contentful-paint']}
       />
       <MetricDistributionGraph
         abbreviation={'TTI'}
         label={'Time to Interactive'}
         statistics={stats('audit_interactive_median')}
         scoreLevels={SCORE_LEVEL_METRIC_THRESHOLDS['interactive']}
+      />
+      <MetricDistributionGraph
+        abbreviation={'SI'}
+        label={'Speed Index'}
+        statistics={stats('audit_speed-index_median')}
+        scoreLevels={SCORE_LEVEL_METRIC_THRESHOLDS['speed-index']}
+      />
+      <MetricDistributionGraph
+        abbreviation={'TBT'}
+        label={'Total Blocking Time'}
+        statistics={stats('audit_total-blocking-time_median')}
+        scoreLevels={SCORE_LEVEL_METRIC_THRESHOLDS['total-blocking-time']}
+      />
+      <MetricDistributionGraph
+        abbreviation={'FID'}
+        label={'Max Potential FID'}
+        statistics={stats('audit_max-potential-fid_median')}
+        scoreLevels={SCORE_LEVEL_METRIC_THRESHOLDS['max-potential-fid']}
       />
     </Fragment>
   );

--- a/packages/server/src/ui/routes/project-dashboard/category-card.jsx
+++ b/packages/server/src/ui/routes/project-dashboard/category-card.jsx
@@ -130,7 +130,7 @@ const MetricDistributionGraphs = props => {
       />
       <MetricDistributionGraph
         abbreviation={'LCP'}
-        label={'First Contentful Paint'}
+        label={'Largest Contentful Paint'}
         statistics={stats('audit_largest-contentful-paint_median')}
         scoreLevels={SCORE_LEVEL_METRIC_THRESHOLDS['largest-contentful-paint']}
       />


### PR DESCRIPTION
This PR will allow users to see LCP, TBT, and FIB in distribution graphs on the dashboard.