### PR TITLE
docs: update CircleCI config example

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -129,13 +129,16 @@ script:
 
 ```yaml
 version: 2.1
+orbs:
+  browser-tools: circleci/browser-tools@1.2.3
 jobs:
   build:
     docker:
-      - image: circleci/node:15.12-browsers
+      - image: cimg/node:16.13-browsers
     working_directory: ~/your-project
     steps:
       - checkout
+      - browser-tools/install-chrome
       - run: npm install
       - run: npm run build
       - run: sudo npm install -g @lhci/cli@0.8.x


### PR DESCRIPTION
CircleCI [deprecated legacy images](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) `circleci/*` and they won't be supported anymore on December 31, 2021.

Updating this to use `cimg/node` instead as well as the `circleci/browser-tools` orb to install Chrome.