### PR TITLE
tests: use relative path in utils test files

### DIFF
--- a/packages/utils/test/assertions.test.js
+++ b/packages/utils/test/assertions.test.js
@@ -7,9 +7,9 @@
 
 /* eslint-env jest */
 
-const lighthouseAllPreset = require('@lhci/utils/src/presets/all.js');
-const {convertBudgetsToAssertions} = require('@lhci/utils/src/budgets-converter.js');
-const {getAllAssertionResults} = require('@lhci/utils/src/assertions.js');
+const lighthouseAllPreset = require('../src/presets/all.js');
+const {convertBudgetsToAssertions} = require('../src/budgets-converter.js');
+const {getAllAssertionResults} = require('../src/assertions.js');
 
 describe('getAllAssertionResults', () => {
   let lhrs;

--- a/packages/utils/test/audit-diff-finder.test.js
+++ b/packages/utils/test/audit-diff-finder.test.js
@@ -17,7 +17,7 @@ const {
   synthesizeItemKeyDiffs,
   sortZippedBaseAndCompareItems,
   replaceNondeterministicStrings,
-} = require('@lhci/utils/src/audit-diff-finder.js');
+} = require('../src/audit-diff-finder.js');
 
 describe('#findAuditDiffs', () => {
   it('should return empty array for identical audits', () => {

--- a/packages/utils/test/budgets-converter.test.js
+++ b/packages/utils/test/budgets-converter.test.js
@@ -10,7 +10,7 @@
 const {
   convertPathExpressionToRegExp,
   convertBudgetsToAssertions,
-} = require('@lhci/utils/src/budgets-converter.js');
+} = require('../src/budgets-converter.js');
 
 describe('convertPathExpressionToRegExp', () => {
   const pathMatch = (path, pattern) => {

--- a/packages/utils/test/saved-reports.test.js
+++ b/packages/utils/test/saved-reports.test.js
@@ -10,7 +10,7 @@
 const fs = require('fs');
 const path = require('path');
 const {withTmpDir} = require('../../cli/test/test-utils.js');
-const {replaceUrlPatterns, saveLHR} = require('@lhci/utils/src/saved-reports.js');
+const {replaceUrlPatterns, saveLHR} = require('../src/saved-reports.js');
 
 describe('#replaceUrlPatterns', () => {
   it('should replace basic patterns', () => {


### PR DESCRIPTION
My editor showed these as errors. It could work locally because the root node_modules symlinks to this subpackage folder, but there's no need to jump through that hoop to test internals of a package.