### PR TITLE
replace isomorphic-fetch with fetch-with-proxy

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "debug": "^4.3.1",
-    "isomorphic-fetch": "^3.0.0",
+    "fetch-with-proxy": "^3.0.1",
     "js-yaml": "^3.13.1",
     "lighthouse": "8.0.0",
     "tree-kill": "^1.2.1"

--- a/packages/utils/src/psi-client.js
+++ b/packages/utils/src/psi-client.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const URL = require('url').URL;
-const fetch = require('isomorphic-fetch');
+const fetch = require('fetch-with-proxy');
 
 const PSI_URL = 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed';
 

--- a/packages/utils/src/psi-client.js
+++ b/packages/utils/src/psi-client.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const URL = require('url').URL;
-const fetch = require('fetch-with-proxy');
+const fetch = require('fetch-with-proxy').default;
 
 const PSI_URL = 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed';
 


### PR DESCRIPTION
This PR will allow users to use PSI strategy even when they are behind a proxy. They will just have to set the appropriate env variables: `HTTP_PROXY` and `HTTPS_PROXY`