### PR TITLE
update dockerfiles to use node 14

### DIFF
--- a/docs/recipes/docker-client/Dockerfile
+++ b/docs/recipes/docker-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-buster-slim
+FROM node:14-buster-slim
 
 # Install utilities
 RUN apt-get update --fix-missing && apt-get -y upgrade && apt-get install -y git wget gnupg && apt-get clean

--- a/docs/recipes/docker-server/Dockerfile
+++ b/docs/recipes/docker-server/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:14-buster-slim
 
+# Install utilities
+RUN apt-get update --fix-missing && apt-get install -y python build-essential && apt-get clean
+
 WORKDIR /usr/src/lhci
 COPY package.json .
 COPY lighthouserc.json .

--- a/docs/recipes/docker-server/Dockerfile
+++ b/docs/recipes/docker-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-buster-slim
+FROM node:14-buster-slim
 
 WORKDIR /usr/src/lhci
 COPY package.json .


### PR DESCRIPTION
Also had to download some build tools to get the server dockerfile to build. It was failing to find a prebuilt sqlite binary for the node+sqlite version, so has to build from source.