### PR TITLE
docs(heroku): fix recipe for Heroku to support LHCI 0.9.0

### DIFF
--- a/docs/recipes/heroku-server/package.json
+++ b/docs/recipes/heroku-server/package.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "main": "server.js",
   "dependencies": {
-    "@lhci/server": "0.7.x",
-    "pg": "^7.12.1",
+    "@lhci/server": "0.9.x",
+    "pg": "^8.2.1",
     "pg-hstore": "^2.3.3"
   },
   "engines": {
-    "node": "12.x"
+    "node": "14.x"
   }
 }


### PR DESCRIPTION
Fixes #775 and related to #779.

We also need to bump node engine to at least 14 as this is the minimum supported version.

cc @connorjclark 