### PR TITLE
Add wait to open

### DIFF
--- a/packages/cli/src/open/open.js
+++ b/packages/cli/src/open/open.js
@@ -46,7 +46,7 @@ async function runCommand(options) {
     process.stdout.write(`Opening median report for ${lhr.finalUrl}...\n`);
     const tmpFile = tmp.fileSync({postfix: '.html'});
     fs.writeFileSync(tmpFile.name, getHTMLReportForLHR(lhr));
-    await open(tmpFile.name);
+    await open(tmpFile.name, {wait: true});
   }
 
   process.stdout.write('Done!\n');


### PR DESCRIPTION
prevent closing shell before report is opened in the browser