### PR TITLE
misc: use cache in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
-      - run: yarn
+          cache: yarn
+      - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: yarn test:unit
       - if: ${{ failure() }}
@@ -71,9 +72,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
+          cache: yarn
       - name: Configure Environment
         run: |-
           echo "CHROME_PATH=$(which google-chrome-stable)" >> $GITHUB_ENV
@@ -86,7 +88,7 @@ jobs:
           mysql --host=127.0.0.1 --port=33306 -e 'create database lighthouse_ci_test;' -u root
 
           google-chrome-stable --version
-      - run: yarn
+      - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: yarn test:typecheck
       - run: yarn test:lint


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Summary

Updated workflows to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data). `setup-node@v3` or newer has caching **built-in**.

### About caching workflow dependencies
Jobs on GitHub-hosted runners start in a clean virtual environment and **must download dependencies each time**, causing increased network utilization, longer runtime, and increased cost. To help speed up the time it takes to recreate files like dependencies, GitHub can cache files that frequently use in workflows.

### Solutions
Node.js projects can run faster on GitHub Actions by enabling dependency caching on the [setup-node](https://github.com/actions/setup-node) action.

### AS-IS

```yaml
- name: Use Node.js 16.x
  uses: actions/setup-node@v1
  with:
    node-version: 16.x
- run: yarn
```

### TO-BE

```yml
- name: Use Node.js 16.x
  uses: actions/setup-node@v3
  with:
    node-version: 16.x
    cache: yarn
- run: yarn install --frozen-lockfile
```

> It’s literally a one line change to pass the `cache: yarn` input parameter.

## Related Issues/PRs
N/A


## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)