### PR TITLE
tests: fix windows unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,9 @@ jobs:
       - name: Run yarn test:unit
         run: yarn test:unit || yarn test:unit || yarn test:unit
       - run: yarn test:docker
-      - run: yarn ci:dogfood
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LHCI_CANARY_SERVER_URL: https://lhci-canary.herokuapp.com/
-          LHCI_CANARY_SERVER_TOKEN: ${{ secrets.LHCI_CANARY_SERVER_TOKEN }}
+      # TODO: re-enable, once we have canary server up again
+      # - run: yarn ci:dogfood
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     LHCI_CANARY_SERVER_URL: https://lhci-canary.herokuapp.com/
+      #     LHCI_CANARY_SERVER_TOKEN: ${{ secrets.LHCI_CANARY_SERVER_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "build:storybook": "lerna run --scope @lhci/server build:storybook",
     "build:watch": "lerna run --scope @lhci/server build:watch --stream",
     "build:source-map-explorer": "lerna run --scope @lhci/server build:source-map-explorer",
-    "start": "./packages/cli/src/cli.js",
+    "start": "node ./packages/cli/src/cli.js",
     "start:seed-data-in-viewer": "node ./scripts/open-seed-report-in-viewer.js",
     "start:seed-database": "node ./scripts/seed-database.js ./packages/cli/test/fixtures/lighthouserc.js",
-    "start:server": "./packages/cli/src/cli.js server --config=./packages/cli/test/fixtures/lighthouserc.js",
+    "start:server": "node ./packages/cli/src/cli.js server --config=./packages/cli/test/fixtures/lighthouserc.js",
     "update:fixture-seed-data": "node ./scripts/update-seed-fixtures.js",
     "test:fixture-seed-data": "jest '--testMatch=**/scripts/diff-seed-fixture.js'",
     "test": "npm run test:typecheck && npm run test:lint && npm run test:unit",
@@ -28,7 +28,7 @@
     "test:unit": "jest --maxWorkers=2"
   },
   "devDependencies": {
-    "@chialab/esbuild-plugin-html": "^0.15.14",
+    "@chialab/esbuild-plugin-html": "^0.17.2",
     "@storybook/addon-actions": "^6.5.13",
     "@storybook/addon-links": "^6.5.13",
     "@storybook/addon-storyshots": "^6.5.13",

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -171,9 +171,6 @@ describe('Lighthouse CI CLI', () => {
   // FIXME: Tests dependency. Moving these tests breaks others.
   describe('collect', () => {
     it('should collect results with a server command', async () => {
-      // FIXME: for some inexplicable reason this test cannot pass in Travis Windows
-      if (os.platform() === 'win32') return;
-
       const startCommand = `yarn start server -p=14927 --storage.sqlDatabasePath=${tmpSqlFilePath}`;
       const {stdout, stderr, status} = await runCLI([
         'collect',

--- a/packages/cli/test/healthcheck.test.js
+++ b/packages/cli/test/healthcheck.test.js
@@ -13,6 +13,8 @@ const path = require('path');
 const rimraf = require('rimraf');
 const {runCLI} = require('./test-utils.js');
 
+jest.setTimeout(60_000);
+
 describe('Lighthouse CI healthcheck CLI', () => {
   const autorunFixtureDir = path.join(__dirname, 'fixtures/autorun-static-dir');
   const rcFile = path.join(autorunFixtureDir, 'lighthouserc.json');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1701,33 +1701,33 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@chialab/esbuild-plugin-html@^0.15.14":
-  version "0.15.14"
-  resolved "https://registry.yarnpkg.com/@chialab/esbuild-plugin-html/-/esbuild-plugin-html-0.15.14.tgz#7eb9836f963f1af02e8aa5b4e6f47467c935628f"
-  integrity sha512-EiI5EEv6H18LUD78IRZG/9RN75rk3hP/AqDUeu4N7COlwwEHwDge9cHOr4NvgZbY6is7T9NVYANlE/MUnmXelA==
+"@chialab/esbuild-plugin-html@^0.17.2":
+  version "0.17.2"
+  resolved "https://registry.yarnpkg.com/@chialab/esbuild-plugin-html/-/esbuild-plugin-html-0.17.2.tgz#6d498db1ad90daf343c37de7be4e0337fd6aa7d6"
+  integrity sha512-IoPRjmiLzoOzJBCJ5sFR5fEjYfQ6EMwuWL1VhZrw1IyDCK34zIqOwmkKk49Tw84VHGkPy/+RUsu8nNP1Ax6liQ==
   dependencies:
-    "@chialab/esbuild-rna" "^0.15.14"
-    "@chialab/node-resolve" "^0.15.9"
+    "@chialab/esbuild-rna" "^0.17.3"
+    "@chialab/node-resolve" "^0.17.0"
 
-"@chialab/esbuild-rna@^0.15.14":
-  version "0.15.14"
-  resolved "https://registry.yarnpkg.com/@chialab/esbuild-rna/-/esbuild-rna-0.15.14.tgz#09263419da96f6b96b6fbe8ed301bde30a4b35b2"
-  integrity sha512-9pviDrC7svGy4V1C6AcAji2HRZ0qbNT3IKapzK8E0NZIRzcay9YK77VJIFyedHEgZqLF1K1iDiG2WP6q2jBCuQ==
+"@chialab/esbuild-rna@^0.17.3":
+  version "0.17.3"
+  resolved "https://registry.yarnpkg.com/@chialab/esbuild-rna/-/esbuild-rna-0.17.3.tgz#07d609436ff081af14046f2f3aa28171cd1769d3"
+  integrity sha512-LwPGDBeRnCNSkUfCEXYWKf7iORt6JCbmCLvEaeZnqle2Tm5yNRtZjCnQHdG9D4UpY9YQgrlZQnF785yOnKwL7Q==
   dependencies:
-    "@chialab/estransform" "^0.15.14"
-    "@chialab/node-resolve" "^0.15.9"
+    "@chialab/estransform" "^0.17.2"
+    "@chialab/node-resolve" "^0.17.0"
 
-"@chialab/estransform@^0.15.14":
-  version "0.15.14"
-  resolved "https://registry.yarnpkg.com/@chialab/estransform/-/estransform-0.15.14.tgz#832f6e68df59f5689b4eb14e5c59bc2f65337777"
-  integrity sha512-o416C85M3jGnzHswOK6MxncfPPTOuNUoJWDWV8FRPKkQzI3avVos+v/bEQVqMJX480lSDqfUHkhZ7gMJIzB2oQ==
+"@chialab/estransform@^0.17.2":
+  version "0.17.3"
+  resolved "https://registry.yarnpkg.com/@chialab/estransform/-/estransform-0.17.3.tgz#f0f9302ae230bf9c09213140ad3ed8560fa312e7"
+  integrity sha512-ZFCcDk85ZllhUiAMIzRFsLhrA2z8xwRyXyJBNMP/84+3czLEydSTzzBK9nXNGloOspwp+lL+EgPlFY8Ry693Bg==
   dependencies:
     "@parcel/source-map" "^2.0.0"
 
-"@chialab/node-resolve@^0.15.9":
-  version "0.15.9"
-  resolved "https://registry.yarnpkg.com/@chialab/node-resolve/-/node-resolve-0.15.9.tgz#46985d4f8a468bbb8443bc624ba60bcc4c72b9a8"
-  integrity sha512-4/2GWaGnMV2CLK4QsG4OyJVb6gcz28XPb/bswYWrH9DmYEx6YXVlNEGDswNJxFeYXvXBCIQ5UGzAzjdEMa075A==
+"@chialab/node-resolve@^0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@chialab/node-resolve/-/node-resolve-0.17.0.tgz#95b73b064e83ce78c23dfbb8b370a0d1f36c2bd0"
+  integrity sha512-u9VwO/0djjXsM70aH/Wrx0BrXjtjhfNOxaDks32xa1mZP9T0CXZ0be5Sv3hXI9g5UeJbfvCyFJS2hfJEu7Ifgg==
 
 "@choojs/findup@^0.2.0":
   version "0.2.1"


### PR DESCRIPTION
- `@chialab/esbuild-plugin-html` needed to be bumped to fix a problem with paths on windows. Otherwise, the server did not build correctly.
- `./script.js` is bad form on Windows, using `node ./script.js` now