### PR TITLE
Fix static subresource paths for server/viewer

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "clean": "rm -rf ./dist ./storybook-static",
     "build": "npm run build:esbuild && npm run build:storybook",
-    "build:esbuild": "node ../../scripts/build-app.js build ./src/ui/index.html ./dist /app",
-    "build:watch": "node ../../scripts/build-app.js watch ./src/ui/index.html ./dist /app",
+    "build:esbuild": "node ../../scripts/build-app.js build ./src/ui/index.html ./dist /app/",
+    "build:watch": "node ../../scripts/build-app.js watch ./src/ui/index.html ./dist /app/",
     "build:source-map-explorer": "npm run clean && npm run build && ../../scripts/source-map-explorer.sh",
     "build:storybook": "build-storybook",
     "start:storybook": "start-storybook -p 6006"

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "clean": "rm -rf ./dist",
     "start": "npm run build:watch",
-    "build": "node ../../scripts/build-app.js build ./src/ui/index.html ./dist",
-    "build:watch": "node ../../scripts/build-app.js watch ./src/ui/index.html ./dist"
+    "build": "node ../../scripts/build-app.js build ./src/ui/index.html ./dist ./",
+    "build:watch": "node ../../scripts/build-app.js watch ./src/ui/index.html ./dist ./"
   },
   "devDependencies": {
     "clsx": "^1.0.4",

--- a/packages/viewer/src/ui/index.html
+++ b/packages/viewer/src/ui/index.html
@@ -9,10 +9,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="../../../server/src/ui/favicon.png" />
-    <title>Lighthouse CI | Viewer</title>
+    <title>Lighthouse CI | Report Diff Tool</title>
   </head>
   <body>
-    <noscript>Lighthouse CI viewer currently requires JavaScript.</noscript>
+    <noscript>Lighthouse CI diff viewer currently requires JavaScript.</noscript>
     <div id="preact-root"></div>
     <script src="entry.jsx"></script>
   </body>

--- a/packages/viewer/src/ui/index.html
+++ b/packages/viewer/src/ui/index.html
@@ -9,10 +9,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="../../../server/src/ui/favicon.png" />
-    <title>Lighthouse CI | Report Diff Tool</title>
+    <title>Lighthouse CI | Viewer</title>
   </head>
   <body>
-    <noscript>Lighthouse CI diff viewer currently requires JavaScript.</noscript>
+    <noscript>Lighthouse CI viewer currently requires JavaScript.</noscript>
     <div id="preact-root"></div>
     <script src="entry.jsx"></script>
   </body>

--- a/scripts/build-app.js
+++ b/scripts/build-app.js
@@ -79,7 +79,7 @@ async function main() {
     entryPoints: [entryPoint],
     entryNames: '[name]',
     assetNames: 'assets/[name]-[hash]',
-    // Defined chunknames breaks the viewer (probably cuz the -plugin-html), but pairs with fixHtmlSubresourceUrls.
+    // See the special handling in fixHtmlSubresourceUrls.
     chunkNames: `chunks/[name]-[hash]`,
     plugins: [htmlPlugin()],
     loader: {

--- a/scripts/source-map-explorer.sh
+++ b/scripts/source-map-explorer.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-sed -i '' 's/sourceMappingURL=\/app/sourceMappingURL=./' ./dist/*.js
-source-map-explorer dist/entry.*.js
+set -euo pipefail
+
+sed -i '' 's/sourceMappingURL=\/app\/chunks/sourceMappingURL=./' ./dist/chunks/*.js
+source-map-explorer dist/chunks/entry*.js

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "noEmit": true,
     "module": "commonjs",
-    "target": "ES2017",
+    "target": "ES2021",
+    "lib": ["ES2021"],
     "allowJs": true,
     "checkJs": true,
     "strict": true,


### PR DESCRIPTION
Fixes #875 

Basically a continuation from last year's https://github.com/GoogleChrome/lighthouse-ci/pull/753 and more specifically https://github.com/GoogleChrome/lighthouse-ci/pull/786

The short version is... esbuild consuming HTML and css is rough. Parcel treated us well.

in 786 we fixed static serving (the viewer) but made sure the express-based serving (the server) still worked.
it did until it didnt. maybe [some dependency bumps](https://github.com/GoogleChrome/lighthouse-ci/issues/875#issuecomment-1440254536)?  shrug.

But...... this works. 
I spent a bunch of time making a more generalized solution. I ended up for something sliiiiightly more specific, but I'm still happy with it.

oh.. and just like in https://github.com/GoogleChrome/lighthouse-ci/pull/786 ... 


<details>
<summary>some development notes</summary>

of course the root problem is plenty of because paths. and express (sometimes) but not all the time.

i used these to iterate.

```sh
# from viewer folder
find ../../scripts/build-app.js ./src/ui | entr bash -c "rm -rf ../viewer/dist/*; yarn build; cat dist/index.html"
# from server folder
find ../../scripts/build-app.js package.json src/| entr bash -c "rm -rf ../server/dist*; yarn build:esbuild; bat dist/index.html"
```

</details>
