### PR TITLE
chore: update lighthouse version to 10.0.2

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
     "https-proxy-agent": "^5.0.0",
     "inquirer": "^6.3.1",
     "isomorphic-fetch": "^3.0.0",
-    "lighthouse": "9.6.8",
+    "lighthouse": "10.0.2",
     "lighthouse-logger": "1.2.0",
     "open": "^7.1.0",
     "tmp": "^0.1.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,7 +13,7 @@
     "debug": "^4.3.1",
     "isomorphic-fetch": "^3.0.0",
     "js-yaml": "^3.13.1",
-    "lighthouse": "9.6.8",
+    "lighthouse": "10.0.2",
     "tree-kill": "^1.2.1"
   }
 }


### PR DESCRIPTION
Our testing is failing with the version of lighthouse used in this version, so this PR updates it