### PR TITLE
detect 11ty's output dir as `staticDistDir`

### DIFF
--- a/packages/cli/src/autorun/autorun.js
+++ b/packages/cli/src/autorun/autorun.js
@@ -28,6 +28,9 @@ const BUILD_DIR_PRIORITY = [
   // likely a built version of the site
   // default name for next.js
   'out',
+  // likely a built version of the site
+  // default name for 11ty
+  '_site',
   // riskier, sometimes is a built version of the site but also can be just a dir of static assets
   // default name for gatsby
   'public',


### PR DESCRIPTION
Hey 👋🏻 

I was surprised when Lighthouse CI didn't detect my built page when setting up a new build. The error message was really helpful, so I got up and running quickly, but I figured I'd ask if you'd consider adding `_site` to the list of automatically detect `staticDistDir` directories.

I figured that it would be a low-risk change, since I suspect that there aren't many directories named `_site` in other systems.

Let me know what you think :)

## References
https://www.11ty.dev/docs/config/#output-directory