### PR TITLE
collect: use new headless mode

### DIFF
--- a/packages/cli/src/collect/node-runner.js
+++ b/packages/cli/src/collect/node-runner.js
@@ -45,7 +45,7 @@ class LighthouseRunner {
     const settings = options.settings || {};
     const chromeFlags = options.settings && options.settings.chromeFlags;
     let chromeFlagsAsString = chromeFlags || '';
-    if (!options.headful) chromeFlagsAsString += ' --headless';
+    if (!options.headful) chromeFlagsAsString += ' --headless=new';
     if (chromeFlagsAsString) settings.chromeFlags = chromeFlagsAsString;
 
     // Make sure we're not passing something that will ruin our runner.

--- a/packages/cli/src/collect/puppeteer-manager.js
+++ b/packages/cli/src/collect/puppeteer-manager.js
@@ -62,7 +62,7 @@ class PuppeteerManager {
       ...(this._options.puppeteerLaunchOptions || {}),
       pipe: false,
       devtools: false,
-      headless: !this._options.headful,
+      headless: this._options.headful ? false : 'new',
       // The default value for `chromePath` is determined by yargs using the `getChromiumPath` method.
       executablePath: this._options.chromePath,
     });

--- a/packages/server/test/test-utils.js
+++ b/packages/server/test/test-utils.js
@@ -289,7 +289,7 @@ module.exports = {
   /** @param {LHCI.E2EState} state */
   launchBrowser: async state => {
     state.browser = await puppeteer.launch({
-      headless: !state.debug,
+      headless: state.debug ? false : 'new',
       slowMo: state.debug ? 250 : undefined,
       devtools: state.debug,
       env: {...process.env, TZ: 'America/Chicago'},

--- a/scripts/test-lh-report.sh
+++ b/scripts/test-lh-report.sh
@@ -9,7 +9,7 @@ LH_ROOT_PATH="$DIRNAME/../.."
 
 cd $LH_ROOT_PATH
 node cli/test/fixtures/static-server.js &
-yarn start http://localhost:10200/dobetterweb/dbw_tester.html --chrome-flags="--headless" --output-path=./lighthouse-ci/ci-test.report.html
+yarn start http://localhost:10200/dobetterweb/dbw_tester.html --chrome-flags="--headless=new" --output-path=./lighthouse-ci/ci-test.report.html
 
 cd ./lighthouse-ci
 export LHCI_CONFIG="./test/fixtures/lighthouserc.json"


### PR DESCRIPTION
Switch to --headless=new when `headful` isn't requested.

This is better in general, but should also fix bfcache results which have issues with the old headless mode (see https://github.com/treosh/lighthouse-ci-action/issues/126, https://github.com/WPO-Foundation/wptagent/pull/605).

I'd like to add a test that the bfcache audit isn't blocked by getting the "Back/forward cache is not supported by delegate" failure anymore, but I haven't found a good place to add that. Happy to take any suggestions!