### PR TITLE
fix(docker): added extra environment variable to lhci-client Dockerfile for puppeteer executable

### DIFF
--- a/docs/recipes/docker-client/Dockerfile
+++ b/docs/recipes/docker-client/Dockerfile
@@ -2,6 +2,7 @@ FROM node:16-bullseye-slim
 
 # Set variable so puppeteer will not try to download chromium
 ENV PUPPETEER_SKIP_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable
 
 # Install utilities
 RUN apt-get update --fix-missing && apt-get -y upgrade && apt-get install -y git wget gnupg && apt-get clean


### PR DESCRIPTION
A while ago I submitted https://github.com/GoogleChrome/lighthouse-ci/pull/736 to fix issues with using puppeteer in the lhci-client docker image. 

In the meantime, puppeteer seems broken again in the latest docker image version. After some investigation, this is most likely a problem occurring after the puppeteer upgrade from v13 to v19. In more recent versions, puppeteer [keeps a cache of browser versions it downloads](https://pptr.dev/guides/configuration#examples). Since in this image we skip the chromium download for puppeteer, because a chrome version is already included for the ligthouse tests, we should specify where our chrome version is located. This was quick fixable by passing the env var in the `docker conatiner run` command, but should in my opinion be defined in the Dockerfile.