### PR TITLE
feat(cli): add static dir file discovery depth flag

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -230,6 +230,9 @@ Options:
   --maxAutodiscoverUrls      The maximum number of pages to collect when using the staticDistDir
                              option with no specified URL. Disable this limit by setting to 0.
                                                                                [number] [default: 5]
+  --staticDirFileDiscoveryDepth The maximum depth of nested folders Lighthouse will look into to discover 
+                                URLs on a static file folder.
+                                                                               [number] [default: 2]
 ```
 
 #### `method`
@@ -418,6 +421,25 @@ lhci collect --staticDistDir=./public --url=http://localhost/products/pricing/
 lhci collect --url=https://example-1.com --url=https://example-2.com
 # Have LHCI start a server and login with puppeteer before running
 lhci collect --start-server-command="yarn serve" --url=http://localhost:8080/ --puppeteer-script=./path/to/login-with-puppeteer.js
+```
+
+### `staticDirFileDiscoveryDepth`
+
+The maximum depth level of nested folders that Lighthouse will look into to discover URLs. If not set, this will default to 2.
+
+### Example
+```text
+
+public/
+├── index.html               #level 0                      
+├── contact/
+│   └── index.html           #level 1
+├── projects/
+│   ├──index.html            #level 1
+│   └── crisis/
+│       ├──index.html        #level 2
+│       └── earthquake/
+│           └── index.html   #level 3
 ```
 
 ---

--- a/packages/cli/src/collect/collect.js
+++ b/packages/cli/src/collect/collect.js
@@ -94,6 +94,12 @@ function buildCommand(yargs) {
       default: 5,
       type: 'number',
     },
+    staticDirFileDiscoveryDepth: {
+      description:
+          'The maximum depth level of nested folders that Lighthouse will look into to discover URLs. If not set, this will default to 2.',
+      default: 2,
+      type: 'number',
+    },
   });
 }
 
@@ -187,7 +193,8 @@ async function startServerAndDetermineUrls(options) {
       : options.autodiscoverUrlBlocklist
       ? [options.autodiscoverUrlBlocklist]
       : [];
-    const availableUrls = server.getAvailableUrls();
+    const maxStaticDirFileDiscoveryDepth = options.staticDirFileDiscoveryDepth || 2;
+    const availableUrls = server.getAvailableUrls(maxStaticDirFileDiscoveryDepth);
     const normalizedBlocklist = autodiscoverUrlBlocklistAsArray.map(rawUrl => {
       const url = new URL(rawUrl, 'http://localhost');
       url.port = server.port.toString();

--- a/packages/cli/src/collect/fallback-server.js
+++ b/packages/cli/src/collect/fallback-server.js
@@ -72,9 +72,20 @@ class FallbackServer {
     );
   }
 
-  /** @return {string[]} */
-  getAvailableUrls() {
-    const htmlFiles = FallbackServer.readHtmlFilesInDirectory(this._pathToBuildDir, 2);
+  /**
+   * @param {number} maxDepth
+   * @return  {string[]}
+   */
+  getAvailableUrls(maxDepth) {
+    if (maxDepth >= 0) {
+      maxDepth = Math.floor(maxDepth);
+    } else {
+      process.stderr.write(
+        `WARNING: staticDirFileDiscoveryDepth must be greater than 0. Defaulting to a discovery depth of 2\n`
+      );
+      maxDepth = 2;
+    }
+    const htmlFiles = FallbackServer.readHtmlFilesInDirectory(this._pathToBuildDir, maxDepth);
     return htmlFiles.map(({file}) => `http://localhost:${this._port}/${file}`);
   }
 

--- a/types/collect.d.ts
+++ b/types/collect.d.ts
@@ -63,6 +63,7 @@ declare global {
         additive: boolean;
         settings?: LighthouseSettings;
         maxAutodiscoverUrls?: number;
+        staticDirFileDiscoveryDepth?: number;
       }
     }
   }


### PR DESCRIPTION
- Added the flag `--staticDirFileDiscoveryDepth` which enables the user to set the depth of search for `index.html` files on a static site folder.

Reason For this feature:
When I ran `lhci autorun` on my static site folder which has deeper folders with `index.html` it did not recognise them after a depth of 2 folders. This is because LHCI currently hard caps it at a depth of 2. I hope the example in the docs changed file explains it.

(This is my first open-source contribution ever. Thank you for this amazing repo!)
