### PR TITLE
chore: remove jest worker limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:lint:jsx": "eslint ./packages/server/src/ui ./packages/viewer/src/ui",
     "test:lint:tests": "eslint ./packages/*/test",
     "test:docker": "bash scripts/test-docker.sh",
-    "test:unit": "jest --maxWorkers=2"
+    "test:unit": "jest"
   },
   "devDependencies": {
     "@chialab/esbuild-plugin-html": "^0.17.2",


### PR DESCRIPTION
This doesn't seem necessary (anymore?).