### PR TITLE
chore: set jest max workers to 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:lint:jsx": "eslint ./packages/server/src/ui ./packages/viewer/src/ui",
     "test:lint:tests": "eslint ./packages/*/test",
     "test:docker": "bash scripts/test-docker.sh",
-    "test:unit": "jest"
+    "test:unit": "jest --maxWorkers=1"
   },
   "devDependencies": {
     "@chialab/esbuild-plugin-html": "^0.17.2",


### PR DESCRIPTION
There are a few tests that I suspect squash each other when run in parallel. The previous value here set max to 2 (probably because the longest test by far - storybook - is not impacted), but that could still result in a problem.

ref #981