### PR TITLE
[Feature] set up additional config `totalBuildsToKeep` for deleteOldBuilds Job

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1050,6 +1050,10 @@ The [cron-style](https://crontab.guru/) schedule on which to collect results.
 
 A number of days to keep a records.
 
+##### `deleteOldBuildsCron[i].totalBuildsToKeep`
+
+A number of total builds to be kept, any builds found there after given will be deleted.
+
 ##### `deleteOldBuildsCron[i].onlyBranches`
 
 Array of branch names, which should be deleted

--- a/packages/server/src/api/storage/sql/sql.js
+++ b/packages/server/src/api/storage/sql/sql.js
@@ -532,6 +532,21 @@ class SqlStorageMethod {
   }
 
   /**
+   * @param {number} totalBuildsToKeep
+   * @return {Promise<LHCI.ServerCommand.Build[]>}
+   */
+  async findRemainingBuilds(totalBuildsToKeep) {
+    const {buildModel} = this._sql();
+    const totalBuilds = await buildModel.count();
+    const remaining = totalBuilds - totalBuildsToKeep;
+    const oldBuilds = await buildModel.findAll({
+      order: [['runAt', 'ASC']],
+      limit: remaining,
+    });
+    return oldBuilds.map(this._value);
+  }
+
+  /**
    * @param {string} projectId
    * @param {string} buildId
    * @return {Promise<void>}

--- a/packages/server/src/api/storage/storage-method.js
+++ b/packages/server/src/api/storage/storage-method.js
@@ -171,6 +171,15 @@ class StorageMethod {
   }
 
   /**
+   * @param {number} totalBuildsToKeep
+   * @return {Promise<LHCI.ServerCommand.Build[]>}
+   */
+  // eslint-disable-next-line no-unused-vars
+  async findRemainingBuilds(totalBuildsToKeep) {
+    throw new Error('Unimplemented');
+  }
+
+  /**
    * @param {string} projectId
    * @param {string} buildId
    * @return {Promise<void>}

--- a/packages/server/src/cron/delete-old-builds.js
+++ b/packages/server/src/cron/delete-old-builds.js
@@ -26,9 +26,15 @@ async function deleteOldBuilds(
 ) {
   if (!maxAgeInDays && !totalBuildsToKeep) {
     throw new Error('At least maxAgeInDays or totalBuildsToKeep should be set');
-  } else if (!totalBuildsToKeep && maxAgeInDays && maxAgeInDays <= 0 || !totalBuildsToKeep && !Number.isInteger(maxAgeInDays)) {
+  } else if (
+    !totalBuildsToKeep && maxAgeInDays && maxAgeInDays <= 0 ||
+    !totalBuildsToKeep && !Number.isInteger(maxAgeInDays)
+  ) {
     throw new Error('Invalid range for maxAgeInDays');
-  } else if (!maxAgeInDays && totalBuildsToKeep && totalBuildsToKeep <= 0 || !maxAgeInDays && !Number.isInteger(totalBuildsToKeep)) {
+  } else if (
+    !maxAgeInDays && totalBuildsToKeep && totalBuildsToKeep <= 0 ||
+    !maxAgeInDays && !Number.isInteger(totalBuildsToKeep)
+  ) {
     throw new Error('Invalid range for totalBuildsToKeep');
   }
   /** @type {LHCI.ServerCommand.Build[]} */

--- a/packages/server/src/cron/delete-old-builds.js
+++ b/packages/server/src/cron/delete-old-builds.js
@@ -27,13 +27,13 @@ async function deleteOldBuilds(
   if (!maxAgeInDays && !totalBuildsToKeep) {
     throw new Error('At least maxAgeInDays or totalBuildsToKeep should be set');
   } else if (
-    !totalBuildsToKeep && maxAgeInDays && maxAgeInDays <= 0 ||
-    !totalBuildsToKeep && !Number.isInteger(maxAgeInDays)
+    (!totalBuildsToKeep && maxAgeInDays && maxAgeInDays <= 0) ||
+    (!totalBuildsToKeep && !Number.isInteger(maxAgeInDays))
   ) {
     throw new Error('Invalid range for maxAgeInDays');
   } else if (
-    !maxAgeInDays && totalBuildsToKeep && totalBuildsToKeep <= 0 ||
-    !maxAgeInDays && !Number.isInteger(totalBuildsToKeep)
+    (!maxAgeInDays && totalBuildsToKeep && totalBuildsToKeep <= 0) ||
+    (!maxAgeInDays && !Number.isInteger(totalBuildsToKeep))
   ) {
     throw new Error('Invalid range for totalBuildsToKeep');
   }

--- a/packages/server/test/cron/delete-old-builds.test.js
+++ b/packages/server/test/cron/delete-old-builds.test.js
@@ -33,17 +33,14 @@ describe('cron/delete-old-builds', () => {
     });
   });
   describe('.deleteOldBuilds', () => {
-    it.each([-1,  new Date()])(
-      'should throw for invalid range (%s)',
-      async range => {
-        await expect(deleteOldBuilds(storageMethod, range)).rejects.toMatchObject({
-          message: 'Invalid range for maxAgeInDays',
-        });
-        await expect(deleteOldBuilds(storageMethod, null, range)).rejects.toMatchObject({
-          message: 'Invalid range for totalBuildsToKeep',
-        });
-      }
-    );
+    it.each([-1, new Date()])('should throw for invalid range (%s)', async range => {
+      await expect(deleteOldBuilds(storageMethod, range)).rejects.toMatchObject({
+        message: 'Invalid range for maxAgeInDays',
+      });
+      await expect(deleteOldBuilds(storageMethod, null, range)).rejects.toMatchObject({
+        message: 'Invalid range for totalBuildsToKeep',
+      });
+    });
 
     it.each([null, undefined])(
       'should throw for At least maxAgeInDays or totalBuildsToKeep should be set (%s)',

--- a/packages/utils/src/api-client.js
+++ b/packages/utils/src/api-client.js
@@ -391,6 +391,15 @@ class ApiClient {
   }
 
   /**
+   * @param {number} totalBuildsToKeep
+   * @return {Promise<LHCI.ServerCommand.Build[]>}
+   */
+  // eslint-disable-next-line no-unused-vars
+  async findRemainingBuilds(totalBuildsToKeep) {
+    throw new Error('Unimplemented');
+  }
+
+  /**
    * @param {string} projectId
    * @return {Promise<string>}
    */

--- a/types/server.d.ts
+++ b/types/server.d.ts
@@ -202,7 +202,8 @@ declare global {
 
       export interface DeleteOldBuildsCron {
         schedule: string;
-        maxAgeInDays: number;
+        maxAgeInDays?: number;
+        totalBuildsToKeep?: number;
         onlyBranches?: string[];
         skipBranches?: string[];
       }


### PR DESCRIPTION
## Background

We've found over time that different Projects have more activity than others. We've seen the MAX history for a specific runURL can be as little as 3 weeks ago. Where less frequently tested projects can have a history of 3 Months within the same amount of builds shown in the graph. Due to this wide range we have 2 months worth of builds for the busier project that are unviewable in the UI. 

To keep storage optimisied we think the option to be able to keep a MAX amount of builds (like 150 or whatever is available to be viewed in the UI) would be more suitable for the different project types.  We don't want to limit all projects to three weeks as they may not make as many frequent changes.

## Changes

- Added server config `totalBuildsToKeep` as part of `deleteOldBuildsCron`
- Added `findRemainingBuilds` method to `storage-method` to return builds found after `totalBuildsToKeep`
- Changed Configuration Docs for `totalBuildsToKeep`
- Changed Tests and Logic around deleteOldBuilds
- Changed `maxAgeInDays` to be an optional config option. Now either `totalBuildsToKeep` or `maxAgeInDays` can be used or both?

