### PR TITLE
Changes to use CLI args to configure VIEWER_ORIGIN for lighthouse server

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -171,3 +171,19 @@ const lhci = require('@lhci/server');
 ### Firewall Rules
 
 You can also protect your server through firewall rules to prevent it from being accessed from outside your internal network. Refer to your infrastructure provider's documentation on how to setup firewall rules to block external IP addresses from accessing the server. Don't forget to allow your CI machines!
+
+### Self-Hosted Lighthouse Report Viewer
+
+If you are hosting your own lighthouse report viewer instead of using the [default viewer](https://googlechrome.github.io/lighthouse/viewer), you can add `--viewer.origin` to your lighthouse server configuration. Eg.
+
+```js
+const {createServer} = require('@lhci/server');
+
+console.log('Starting server...');
+createServer({
+  ...
+  viewer: {
+    origin: 'https://viewer-url' // Default: https://googlechrome.github.io
+  }
+}).then(({port}) => console.log('LHCI listening on port', port));
+```

--- a/packages/cli/src/server/server.js
+++ b/packages/cli/src/server/server.js
@@ -65,6 +65,11 @@ function buildCommand(yargs) {
       type: 'string',
       description: 'The password to protect the server with HTTP Basic Authentication.',
     },
+    'viewer.origin': {
+      type: 'string',
+      description: 'The url origin for self-hosted lighthouse report viewer.',
+      default: 'https://googlechrome.github.io',
+    }
   });
 }
 

--- a/packages/server/src/api/routes/viewer.js
+++ b/packages/server/src/api/routes/viewer.js
@@ -1,0 +1,29 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const express = require('express');
+const { handleAsyncError } = require('../express-utils.js');
+
+/**
+ * @param {LHCI.ServerCommand.Options} options
+ * @return {import('express').Router}
+ */
+function createRouter(options) {
+  const router = express.Router(); // eslint-disable-line new-cap
+
+  // GET /viewer/origin
+  router.get(
+    '/origin',
+    handleAsyncError(async (_, res) => {
+      res.json({ viewerOrigin: options.viewer?.origin });
+    })
+  );
+
+  return router;
+}
+
+module.exports = createRouter;

--- a/packages/server/src/api/routes/viewer.js
+++ b/packages/server/src/api/routes/viewer.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const express = require('express');
-const { handleAsyncError } = require('../express-utils.js');
+const {handleAsyncError} = require('../express-utils.js');
 
 /**
  * @param {LHCI.ServerCommand.Options} options

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -16,6 +16,7 @@ const compression = require('compression');
 const bodyParser = require('body-parser');
 const ApiClient = require('@lhci/utils/src/api-client.js');
 const createProjectsRouter = require('./api/routes/projects.js');
+const createViewerRouter = require('./api/routes/viewer.js');
 const StorageMethod = require('./api/storage/storage-method.js');
 const {errorMiddleware, createBasicAuthMiddleware} = require('./api/express-utils.js');
 const {startPsiCollectCron} = require('./cron/psi-collect.js');
@@ -60,6 +61,7 @@ async function createApp(options) {
   app.get('/', (_, res) => res.redirect('/app'));
   app.use('/version', (_, res) => res.send(version));
   app.use('/v1/projects', createProjectsRouter(context));
+  app.use('/v1/viewer', createViewerRouter(options));
   app.use('/app', express.static(DIST_FOLDER));
   app.get('/app/*', (_, res) => res.sendFile(path.join(DIST_FOLDER, 'index.html')));
   app.use(errorMiddleware);

--- a/packages/server/src/ui/components/lhr-viewer-link.jsx
+++ b/packages/server/src/ui/components/lhr-viewer-link.jsx
@@ -7,14 +7,16 @@
 import {h} from 'preact';
 import clsx from 'clsx';
 import {useState} from 'preact/hooks';
+import { api } from '../hooks/use-api-data';
 import './lhr-viewer-link.css';
 
 /** @typedef {LH.Result|(() => Promise<LH.Result>)} LHResolver */
 
 /** @param {LH.Result} lhr */
-export function openLhrInClassicViewer(lhr) {
+export async function openLhrInClassicViewer(lhr) {
   // Allows for self-hosted viewer uri instead of linking externally
-  const VIEWER_ORIGIN = process.env.VIEWER_ORIGIN || 'https://googlechrome.github.io';
+  const cliViewerOrigin = await api.getViewerOrigin();
+  const VIEWER_ORIGIN = process.env.VIEWER_ORIGIN || cliViewerOrigin;
   // Chrome doesn't allow us to immediately postMessage to a popup right
   // after it's created. Normally, we could also listen for the popup window's
   // load event, however it is cross-domain and won't fire. Instead, listen

--- a/packages/server/src/ui/components/lhr-viewer-link.jsx
+++ b/packages/server/src/ui/components/lhr-viewer-link.jsx
@@ -7,7 +7,7 @@
 import {h} from 'preact';
 import clsx from 'clsx';
 import {useState} from 'preact/hooks';
-import { api } from '../hooks/use-api-data';
+import {api} from '../hooks/use-api-data';
 import './lhr-viewer-link.css';
 
 /** @typedef {LH.Result|(() => Promise<LH.Result>)} LHResolver */

--- a/packages/utils/src/api-client.js
+++ b/packages/utils/src/api-client.js
@@ -344,6 +344,13 @@ class ApiClient {
   }
 
   /**
+   * @return {Promise<string>}
+   */
+  async getViewerOrigin() {
+    return this._get('/v1/viewer/origin');
+  }
+
+  /**
    * @param {StrictOmit<LHCI.ServerCommand.Project, 'id'|'token'|'adminToken'>} unsavedProject
    * @return {Promise<LHCI.ServerCommand.Project>}
    */

--- a/types/server.d.ts
+++ b/types/server.d.ts
@@ -198,6 +198,9 @@ declare global {
           username?: string;
           password?: string;
         };
+        viewer?: {
+          origin?: string;
+        };
       }
 
       export interface DeleteOldBuildsCron {


### PR DESCRIPTION
Hi,

I like the solution in #637 which allows us to change the default self-hosted lighthouse report viewer. However, I noticed that the `$VIEWER_ORIGIN` environment variable works only if you build a custom `@lhci/server` package. Hence, I made some modifications to configure `$VIEWER_ORIGIN` for `@lhci/server` via the CLI args.

I changed the following things:

- added an optional `--viewer.origin` cli args for server (Default: https://googlechrome.github.io) 
- added `/v1/viewer/origin` endpoint that retrieves the `viewer.origin` value
- updated the server docs

This may not be the most optimal solution, so I would appreciate any feedback on my approach and code changes. Thank you :)