### PR TITLE
feat(cli): add --lhr to assert command to load LHRs from anywhere

### DIFF
--- a/packages/cli/src/assert/assert.js
+++ b/packages/cli/src/assert/assert.js
@@ -32,6 +32,10 @@ function buildCommand(yargs) {
       type: 'boolean',
       description: 'Whether to include the results of passed assertions in the output.',
     },
+    lhr: {
+      description:
+        'Path to LHRs (either a folder or a single file path). Not recursive. If not provided, .lighthouseci is used',
+    },
   });
 }
 
@@ -53,7 +57,7 @@ async function runCommand(options) {
   // If we have a budgets file, convert it to our assertions format.
   if (budgetsFile) options = await convertBudgetsToAssertions(readBudgets(budgetsFile));
 
-  const lhrs = loadSavedLHRs().map(json => JSON.parse(json));
+  const lhrs = loadSavedLHRs(options.lhr).map(json => JSON.parse(json));
   const uniqueUrls = new Set(lhrs.map(lhr => lhr.finalUrl));
   const allResults = getAllAssertionResults(options, lhrs);
   const groupedResults = _.groupBy(allResults, result => result.url);

--- a/packages/utils/src/saved-reports.js
+++ b/packages/utils/src/saved-reports.js
@@ -18,14 +18,23 @@ function ensureDirectoryExists(baseDir = LHCI_DIR) {
 }
 
 /**
+ * @param {string} [directoryOrPath]
  * @return {string[]}
  */
-function loadSavedLHRs() {
-  ensureDirectoryExists();
+function loadSavedLHRs(directoryOrPath) {
+  directoryOrPath = directoryOrPath || LHCI_DIR;
+
+  if (directoryOrPath === LHCI_DIR) {
+    ensureDirectoryExists();
+  }
+
+  if (fs.lstatSync(directoryOrPath).isFile()) {
+    return [fs.readFileSync(directoryOrPath, 'utf8')];
+  }
 
   /** @type {string[]} */
   const lhrs = [];
-  for (const file of fs.readdirSync(LHCI_DIR)) {
+  for (const file of fs.readdirSync(directoryOrPath)) {
     if (!LHR_REGEX.test(file)) continue;
 
     const filePath = path.join(LHCI_DIR, file);

--- a/types/assert.d.ts
+++ b/types/assert.d.ts
@@ -38,6 +38,7 @@ declare global {
         includePassedAssertions?: boolean;
         budgetsFile?: string;
         assertMatrix?: BaseOptions[];
+        lhr?: string;
       }
 
       /**


### PR DESCRIPTION
ref https://github.com/GoogleChrome/lighthouse/issues/15203

Enables usage like this:

```
node packages/cli/src/cli.js -no-lighthouserc assert \
  --lhr /Users/cjamcl/src/lighthouse/core/test/results/sample_v2.json \
  --budgetsFile=packages/cli/test/fixtures/budgets.json
```
