### PR TITLE
fix(cli): respect collect puppeteerLaunchOptions.headless

### DIFF
--- a/packages/cli/src/collect/collect.js
+++ b/packages/cli/src/collect/collect.js
@@ -33,7 +33,10 @@ function buildCommand(yargs) {
       choices: ['node', 'psi'],
       default: 'node',
     },
-    headful: {type: 'boolean', description: 'Run with a headful Chrome'},
+    headful: {
+      description:
+        'Run with a headful Chrome (pass `headless: false` to puppeteer). Overrides value of `puppeteerLaunchOptions.headless`',
+    },
     additive: {type: 'boolean', description: 'Skips clearing of previous collect data'},
     url: {
       description:

--- a/packages/cli/src/collect/puppeteer-manager.js
+++ b/packages/cli/src/collect/puppeteer-manager.js
@@ -58,14 +58,19 @@ class PuppeteerManager {
       throw new Error(`Unable to require 'puppeteer' for script, have you run 'npm i puppeteer'?`);
     }
 
-    this._browser = await puppeteer.launch({
+    /** @type {import('puppeteer').PuppeteerLaunchOptions} */
+    const args = {
       ...(this._options.puppeteerLaunchOptions || {}),
+      headless: 'new',
       pipe: false,
       devtools: false,
-      headless: this._options.headful ? false : 'new',
       // The default value for `chromePath` is determined by yargs using the `getChromiumPath` method.
       executablePath: this._options.chromePath,
-    });
+    };
+    if (this._options.headful === true) {
+      args.headless = false;
+    }
+    this._browser = await puppeteer.launch(args);
 
     return this._browser;
   }

--- a/types/collect.d.ts
+++ b/types/collect.d.ts
@@ -56,10 +56,10 @@ declare global {
         chromePath?: string;
         puppeteerScript?: string;
         /** @see https://github.com/puppeteer/puppeteer/blob/v2.0.0/docs/api.md#puppeteerlaunchoptions */
-        puppeteerLaunchOptions?: import('puppeteer').LaunchOptions;
+        puppeteerLaunchOptions?: import('puppeteer').PuppeteerLaunchOptions;
         method: 'node' | 'psi';
         numberOfRuns: number;
-        headful: boolean;
+        headful?: boolean;
         additive: boolean;
         settings?: LighthouseSettings;
         maxAutodiscoverUrls?: number;


### PR DESCRIPTION
Fixes #947 by only overriding to `headless: false` when `--headful` is present.