### PR TITLE
chore(wizard): change default branch default to main

### DIFF
--- a/packages/cli/src/wizard/wizard.js
+++ b/packages/cli/src/wizard/wizard.js
@@ -54,7 +54,7 @@ async function runNewProjectWizard(options) {
       type: 'input',
       name: 'projectBaseBranch',
       message: "What branch is considered the repo's trunk or main branch?",
-      default: 'master',
+      default: 'main',
     },
   ]);
 


### PR DESCRIPTION
Since the broad adaption and change of policy to have the main branch to be called main, it's time to set default in the wizard to main as well