### PR TITLE
Add debug logging

### DIFF
--- a/packages/cli/src/collect/collect.js
+++ b/packages/cli/src/collect/collect.js
@@ -37,6 +37,7 @@ function buildCommand(yargs) {
       description:
         'Run with a headful Chrome (pass `headless: false` to puppeteer). Overrides value of `puppeteerLaunchOptions.headless`',
     },
+    debug: {type: 'boolean', description: 'Prints the output of the lighthouse command to the console'},
     additive: {type: 'boolean', description: 'Skips clearing of previous collect data'},
     url: {
       description:

--- a/packages/cli/src/collect/node-runner.js
+++ b/packages/cli/src/collect/node-runner.js
@@ -100,6 +100,14 @@ class LighthouseRunner {
     child.stdout.on('data', chunk => (stdout += chunk.toString()));
     child.stderr.on('data', chunk => (stderr += chunk.toString()));
 
+    if(options.debug){
+
+      //If the debug flag is true, print the output of the lighthouse command (Provided on stderr)
+      //to the console (stdout)
+      child.stderr.on('data', chunk => process.stdout.write(chunk.toString()));
+
+    }
+
     child.on('exit', code => {
       cleanupFn();
       if (code === 0) return resolve(stdout);


### PR DESCRIPTION
Add an option to output the output of the lighthouse run in collect.

I'm struggling to figure out why my LHCI runs are hanging as discussed in #638, so am submitting this PR, at this point more for guidance that any expectation that it will be merged.

Not a node developer!