### PR TITLE
Update package.json - Bump lhci version

### DIFF
--- a/docs/recipes/heroku-server/package.json
+++ b/docs/recipes/heroku-server/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "server.js",
   "dependencies": {
-    "@lhci/server": "0.9.x",
+    "@lhci/server": "0.14.x",
     "pg": "^8.2.1",
     "pg-hstore": "^2.3.3"
   },


### PR DESCRIPTION
Current package.json refers to 0.9.0 but latest stable version is 0.14.0