### PR TITLE
Update audit IDs reference link in configuration documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -690,7 +690,7 @@ Options:
 
 #### `assertions`
 
-The result of any audit in Lighthouse can be asserted. Assertions are keyed by the Lighthouse audit ID and follow an eslint-style format of `level | [level, options]`. For a reference of the audit IDs in each category, you can take a look at the [default Lighthouse config](https://github.com/GoogleChrome/lighthouse/blob/v5.5.0/lighthouse-core/config/default-config.js#L375-L407). When no options are set, the default options of `{"aggregationMethod": "optimistic", "minScore": 1}` are used.
+The result of any audit in Lighthouse can be asserted. Assertions are keyed by the Lighthouse audit ID and follow an eslint-style format of `level | [level, options]`. For a reference of the audit IDs in each category, you can take a look at the [default Lighthouse config](https://github.com/GoogleChrome/lighthouse/blob/v12.2.1/core/config/default-config.js#L381-L432). When no options are set, the default options of `{"aggregationMethod": "optimistic", "minScore": 1}` are used.
 
 ```jsonc
 {


### PR DESCRIPTION
Updates the [default Lighthouse config](https://github.com/GoogleChrome/lighthouse/blob/v12.2.1/core/config/default-config.js#L381-L432) link to the latest release. The file has changed locations, and there are a lot of audit changes (going from 33 to 49 just for the performance category), so I thought this would be worth updating.

If this feels useful I’m happy to also update other links to the Lighthouse source elsewhere in the documentation, though none of the ones I stumbled upon showed such significant changes as this one.