### PR TITLE
docs: update link to default lighthouse config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -690,7 +690,7 @@ Options:
 
 #### `assertions`
 
-The result of any audit in Lighthouse can be asserted. Assertions are keyed by the Lighthouse audit ID and follow an eslint-style format of `level | [level, options]`. For a reference of the audit IDs in each category, you can take a look at the [default Lighthouse config](https://github.com/GoogleChrome/lighthouse/blob/v5.5.0/lighthouse-core/config/default-config.js#L375-L407). When no options are set, the default options of `{"aggregationMethod": "optimistic", "minScore": 1}` are used.
+The result of any audit in Lighthouse can be asserted. Assertions are keyed by the Lighthouse audit ID and follow an eslint-style format of `level | [level, options]`. For a reference of the audit IDs in each category, you can take a look at the [default Lighthouse config](https://github.com/GoogleChrome/lighthouse/blob/main/core/config/default-config.js#L383-L434). When no options are set, the default options of `{"aggregationMethod": "optimistic", "minScore": 1}` are used.
 
 ```jsonc
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -690,7 +690,7 @@ Options:
 
 #### `assertions`
 
-The result of any audit in Lighthouse can be asserted. Assertions are keyed by the Lighthouse audit ID and follow an eslint-style format of `level | [level, options]`. For a reference of the audit IDs in each category, you can take a look at the [default Lighthouse config](https://github.com/GoogleChrome/lighthouse/blob/main/core/config/default-config.js#L383-L434). When no options are set, the default options of `{"aggregationMethod": "optimistic", "minScore": 1}` are used.
+The result of any audit in Lighthouse can be asserted. Assertions are keyed by the Lighthouse audit ID and follow an eslint-style format of `level | [level, options]`. For a reference of the audit IDs in each category, you can take a look at the [default Lighthouse config](https://github.com/GoogleChrome/lighthouse/blob/main/core/config/default-config.js). When no options are set, the default options of `{"aggregationMethod": "optimistic", "minScore": 1}` are used.
 
 ```jsonc
 {


### PR DESCRIPTION
Currently, the link to the default config in the configuration doc for assertions references a specific version v5.5.0. I updated it to reference the main branch.

Resolves #1075