### PR TITLE
Fixed typo in documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -406,7 +406,7 @@ Note that the following options cannot be used because LHCI uses them internally
 
 #### `numberOfRuns`
 
-The number of times to collect Lighthouse results on each `url`. This option helps mitigate fluctations due to natural page [variability](https://github.com/GoogleChrome/lighthouse/blob/v6.0.0-beta.0/docs/variability.md).
+The number of times to collect Lighthouse results on each `url`. This option helps mitigate fluctuations due to natural page [variability](https://github.com/GoogleChrome/lighthouse/blob/v6.0.0-beta.0/docs/variability.md).
 
 #### Examples
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,4 +1,4 @@
-# Configuration
+# Configuration 
 
 ## Overview
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,4 +1,4 @@
-# Configuration 
+# Configuration
 
 ## Overview
 


### PR DESCRIPTION
This pull request includes a minor documentation fix in the `docs/configuration.md` file. It corrects a typographical error in the description of the `numberOfRuns` option by fixing the spelling of "fluctations" to "fluctuations."