### PR TITLE
fix: use viewer origin as string instead of object

### DIFF
--- a/packages/server/src/ui/components/lhr-viewer-link.jsx
+++ b/packages/server/src/ui/components/lhr-viewer-link.jsx
@@ -15,7 +15,7 @@ import './lhr-viewer-link.css';
 /** @param {LH.Result} lhr */
 export async function openLhrInClassicViewer(lhr) {
   // Allows for self-hosted viewer uri instead of linking externally
-  const cliViewerOrigin = await api.getViewerOrigin();
+  const cliViewerOrigin = (await api.getViewerOrigin()).viewerOrigin || 'https://googlechrome.github.io';
   const VIEWER_ORIGIN = process.env.VIEWER_ORIGIN || cliViewerOrigin;
   // Chrome doesn't allow us to immediately postMessage to a popup right
   // after it's created. Normally, we could also listen for the popup window's

--- a/packages/utils/src/api-client.js
+++ b/packages/utils/src/api-client.js
@@ -344,7 +344,7 @@ class ApiClient {
   }
 
   /**
-   * @return {Promise<string>}
+   * ⁠@return {Promise<{viewerOrigin: string}>}
    */
   async getViewerOrigin() {
     return this._get('/v1/viewer/origin');


### PR DESCRIPTION
api.getViewerOrigin() returns the object {"viewerOrigin": "<URL>"} instead of the string value. This causes malformed report URL. Clicking on the report link redirects to the home page because of this. The URL constructs as ´{projectURL}/[object%20Object]/lighthouse/viewer´.  This fix replaces the [object%20Object] with actual string value. 
