### PR TITLE
Use latest GitHub Action for checkout

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,7 +84,7 @@ jobs:
     name: Lighthouse
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js 16.x
         uses: actions/setup-node@v3
         with:
@@ -360,7 +360,7 @@ jobs:
     name: Lighthouse
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Use Node.js 16.x

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,7 +84,7 @@ jobs:
     name: Lighthouse
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js 16.x
         uses: actions/setup-node@v3
         with:
@@ -360,7 +360,7 @@ jobs:
     name: Lighthouse
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Use Node.js 16.x


### PR DESCRIPTION
Just a quick bump. Thank you.

---

Documentation reference for supporting this change:

https://github.com/actions/checkout/releases