### PR TITLE
fix: Escape special characters in regex pattern

### DIFF
--- a/packages/cli/src/collect/collect.js
+++ b/packages/cli/src/collect/collect.js
@@ -19,6 +19,15 @@ const {
 } = require('@lhci/utils/src/child-process-helper.js');
 
 /**
+ * Escapes special characters in a string so it can be used as a literal pattern in a RegExp.
+ * @param {string} value
+ * @return {string}
+ */
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
  * @param {import('yargs').Argv} yargs
  */
 function buildCommand(yargs) {
@@ -159,7 +168,8 @@ async function startServerAndDetermineUrls(options) {
 
     let close = async () => undefined;
     if (options.startServerCommand) {
-      const regexPattern = new RegExp(options.startServerReadyPattern, 'i');
+      const safePattern = escapeRegExp(String(options.startServerReadyPattern || ''));
+      const regexPattern = new RegExp(safePattern, 'i');
       const {child, patternMatch, stdout, stderr} = await runCommandAndWaitForPattern(
         options.startServerCommand,
         regexPattern,

--- a/packages/utils/src/assertions.js
+++ b/packages/utils/src/assertions.js
@@ -284,7 +284,17 @@ function getCategoryAssertionResults(auditProperty, assertionOptions, lhrs) {
  * @return {boolean}
  */
 function doesLHRMatchPattern(pattern, lhr) {
-  return new RegExp(pattern).test(lhr.finalUrl);
+  let regex;
+  try {
+    regex = new RegExp(pattern);
+  } catch (err) {
+    // Surface a clearer error message when the provided pattern is not a valid regular expression.
+    throw new Error(
+      `Invalid matchingUrlPattern "${pattern}": ${(/** @type {Error} */ (err)).message}`
+    );
+  }
+
+  return regex.test(lhr.finalUrl);
 }
 
 /**

--- a/packages/utils/src/build-context.js
+++ b/packages/utils/src/build-context.js
@@ -8,6 +8,15 @@
 const crypto = require('crypto');
 const childProcess = require('child_process');
 
+/**
+ * Escape special characters in a string so it can be used safely inside a RegExp.
+ * @param {string} string
+ * @return {string}
+ */
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /** @param {Array<string>} namesInPriorityOrder @return {string|undefined} */
 function getEnvVarIfSet(namesInPriorityOrder) {
   for (const name of namesInPriorityOrder) {
@@ -372,7 +381,8 @@ function getGitHubRepoSlug(apiHost = undefined) {
   if (remote && apiHost && !apiHost.includes('github.com')) {
     const hostMatch = apiHost.match(/:\/\/(.*?)(\/|$)/);
     if (!hostMatch) return undefined;
-    const remoteRegex = new RegExp(`${hostMatch[1]}(:|\\/)([^/]+\\/.+)\\.git`);
+    const safeHost = escapeRegExp(hostMatch[1]);
+    const remoteRegex = new RegExp(`${safeHost}(:|\\/)([^/]+\\/.+)\\.git`);
     const remoteMatch = remote.match(remoteRegex);
     if (remoteMatch) return remoteMatch[2];
   }


### PR DESCRIPTION
https://github.com/GoogleChrome/lighthouse-ci/blob/ebee453dad3f8acacd657a62ccc65e3296afb7d0/packages/cli/src/collect/collect.js#L162

Constructing a regular expression with unsanitized user input is dangerous as a malicious user may be able to modify the meaning of the expression. In particular, such a user may be able to provide a regular expression fragment that takes exponential time in the worst case, and use that to perform a Denial of Service attack.

General approach: Avoid constructing a `RegExp` directly from unsanitized user input or, if regular expressions must be user‑supplied, validate or constrain them to prevent pathological behavior. Common options are: escaping meta‑characters (turning input into a literal pattern), whitelisting simple allowed constructs, or rejecting patterns that exceed size/complexity limits.

Best fix here without changing intended functionality too much:

- `startServerReadyPattern` is meant to be “a pattern the server prints when it is ready.” In practice, users usually specify a literal string like `Listening on 8080`. Treating this as a literal substring search is sufficient and simpler than exposing full regex power.
- We can still use `RegExp`, but we should escape all regex metacharacters in the user input so it’s interpreted literally. This preserves user expectations for simple patterns and removes the ability to inject complex or catastrophic regexes.
- Implement a small helper function `escapeRegExp` in `collect.js` (rather than adding new dependencies) and apply it to `options.startServerReadyPattern` before constructing the `RegExp`.

Concretely:

1. In `packages/cli/src/collect/collect.js`, define a local `escapeRegExp` utility near the top of the file.
2. In `startServerAndDetermineUrls`, replace the line:

   ```js
   const regexPattern = new RegExp(options.startServerReadyPattern, 'i');
   ```

   with:

   ```js
   const safePattern = escapeRegExp(String(options.startServerReadyPattern || ''));
   const regexPattern = new RegExp(safePattern, 'i');
   ```

   This:
   - Coerces the value to string and safely handles `undefined`/`null`.
   - Escapes all regex metacharacters, preventing injection.