### PR TITLE
Modernize "Getting Started" Guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
       YARN_GPG: 'no'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Use Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 18
           cache: yarn
@@ -68,11 +68,11 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Use Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 18
           cache: yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Use Node.js 18
+      - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           cache: yarn
       - run: yarn install --frozen-lockfile
       - run: yarn build
@@ -71,10 +71,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Use Node.js 18
+      - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           cache: yarn
       # Since Ubuntu 23, dev builds of Chromium need this.
       # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
       - run: npm install && npm install -g @lhci/cli@0.15.x
       - run: npm run build
       - run: lhci autorun

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ jobs:
   lighthouseci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 18
       - run: npm install && npm install -g @lhci/cli@0.15.x

--- a/docs/complex-setup.md
+++ b/docs/complex-setup.md
@@ -38,7 +38,7 @@ exit $EXIT_CODE
 
 To run Lighthouse CI, you'll need...
 
-- Node v16 LTS or later
+- Node v18 LTS or later
 - Chrome Stable or later
 - (if Ubuntu) Xenial or later
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -337,7 +337,7 @@ GitHub status checks add additional granularity to your build reporting and dire
 
 #### GitHub Automatic Token (Recommended)
 
-The easiest and most secure way to add status checks to your PR is via the [automatic GITHUB_TOKEN](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token). You need to make sure it has both `contents:read` and `statuses:write` permissions. (See the [full permission reference](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions) for more details).
+The easiest and most secure way to add status checks to your PR is via the [automatic GITHUB_TOKEN](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token). You need to make sure it has both `contents:read` and `statuses:write` permissions.
 
 ```diff
 name: CI

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,10 +86,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Use Node.js 18.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v6
         with:
-          node-version: 18.x
+          node-version: 24.x
       - name: npm install, build
         run: |
           npm install
@@ -199,7 +199,7 @@ echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sud
 wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
 
 # Add Node's apt-key
-curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_24.x | sudo -E bash -
 
 # Install NodeJS and Google Chrome
 sudo apt-get update
@@ -351,10 +351,10 @@ jobs:
 +     statuses: write
     steps:
       - uses: actions/checkout@v6
-      - name: Use Node.js 18.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v6
         with:
-          node-version: 18.x
+          node-version: 24.x
       - name: npm install, build
         run: |
           npm install
@@ -396,10 +396,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Use Node.js 18.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v6
         with:
-          node-version: 18.x
+          node-version: 24.x
       - name: npm install, build
         run: |
           npm install

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,9 +85,9 @@ jobs:
     name: Lighthouse
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 16.x
       - name: npm install, build
@@ -350,9 +350,9 @@ jobs:
 +     contents: read
 +     statuses: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 16.x
       - name: npm install, build
@@ -393,11 +393,11 @@ jobs:
     name: Lighthouse
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 16.x
       - name: npm install, build

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,8 @@
   - [Modifications for Sites without a Build Step](#modifications-for-sites-without-a-build-step)
   - [Modifications for Sites with a Custom Server](#modifications-for-sites-with-a-custom-server)
 - [GitHub Status Checks](#github-status-checks)
-  - [GitHub App Method (Recommended)](#github-app-method-recommended)
+  - [GitHub Automatic Token (Recommended)](#github-automatic-token-recommended)
+  - [Alternative: GitHub App Method](#alternative-github-app-method)
   - [Alternative: Personal Access Token Method](#alternative-personal-access-token-method)
   - [Additional configuration for GitHub Actions as CI Provider](#additional-configuration-for-github-actions-as-ci-provider)
 - [Add Assertions](#add-assertions)
@@ -334,7 +335,39 @@ GitHub status checks add additional granularity to your build reporting and dire
 
 ![screenshot of GitHub status checks for Lighthouse CI](https://user-images.githubusercontent.com/2301202/68001177-0b9dd180-fc31-11e9-8091-ada8c6e50a9b.png)
 
-#### GitHub App Method (Recommended)
+#### GitHub Automatic Token (Recommended)
+
+The easiest and most secure way to add status checks to your PR is via the [automatic GITHUB_TOKEN](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token). You need to make sure it has both `contents:read` and `statuses:write` permissions. (See the [full permission reference](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions) for more details).
+
+```diff
+name: CI
+on: [push]
+jobs:
+  lhci:
+    name: Lighthouse
+    runs-on: ubuntu-latest
++   permissions:
++     contents: read
++     statuses: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - name: npm install, build
+        run: |
+          npm install
+          npm run build
+      - name: run Lighthouse CI
+        run: |
+          npm install -g @lhci/cli@0.15.x
+          lhci autorun
++       env:
++         LHCI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+#### Alternative: GitHub App Method
 
 **NOTE: Before installing the GitHub App, refer to the [terms of service](./services-disclaimer.md#github-app).**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,7 +110,7 @@ jobs:
 
 ```yaml
 language: node_js
-node_js: v16
+node_js: v24
 addons:
   chrome: stable
 before_install:
@@ -135,7 +135,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/node:16.13-browsers
+      - image: cimg/node:24.13-browsers
     working_directory: ~/your-project
     steps:
       - checkout
@@ -172,7 +172,7 @@ module.exports = {
 **.gitlab-ci.yml**
 
 ```yaml
-image: cypress/browsers:node16.17.0-chrome106
+image: cypress/browsers:24.13.0
 lhci:
   script:
     - npm install
@@ -257,16 +257,16 @@ module.exports = {
 steps:
   - id: 'install'
     args: ['npm', 'ci']
-    name: node:16-alpine
+    name: node:24-alpine
 
   - id: 'build'
     waitFor: ['install']
-    name: node:16-alpine
+    name: node:24-alpine
     args: ['npm', 'run', 'build']
 
   - id: 'lighthouse'
     waitFor: ['build']
-    name: cypress/browsers:node16.17.0-chrome106
+    name: cypress/browsers:cypress/browsers:24.13.0
     entrypoint: '/bin/sh'
     args: ['-c', 'npm install -g @lhci/cli@0.15.x && lhci autorun --failOnUploadFailure']
     env:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,10 +86,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v6
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: npm install, build
         run: |
           npm install
@@ -199,7 +199,7 @@ echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sud
 wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
 
 # Add Node's apt-key
-curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
 
 # Install NodeJS and Google Chrome
 sudo apt-get update
@@ -351,10 +351,10 @@ jobs:
 +     statuses: write
     steps:
       - uses: actions/checkout@v6
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v6
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: npm install, build
         run: |
           npm install
@@ -396,10 +396,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v6
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: npm install, build
         run: |
           npm install

--- a/docs/recipes/docker-client/Dockerfile
+++ b/docs/recipes/docker-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bullseye-slim
+FROM node:24-bullseye-slim
 
 # Set variable so puppeteer will not try to download chromium
 ENV PUPPETEER_SKIP_DOWNLOAD=true

--- a/docs/recipes/docker-server/Dockerfile
+++ b/docs/recipes/docker-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bullseye-slim
+FROM node:24-bullseye-slim
 
 # Install utilities
 RUN apt-get update --fix-missing && apt-get install -y python build-essential && apt-get clean

--- a/docs/recipes/heroku-server/README.md
+++ b/docs/recipes/heroku-server/README.md
@@ -25,6 +25,8 @@ This assumes you've already signed up, created a heroku account, and installed t
 ```bash
 # Create a new project on heroku
 heroku create
+# Setup the Heroku git remote
+heroku git:remote -a <project-name-from-above>
 # Add a database to your project
 heroku addons:create heroku-postgresql:essential-0
 # Deploy your code to heroku

--- a/docs/recipes/heroku-server/package.json
+++ b/docs/recipes/heroku-server/package.json
@@ -8,6 +8,6 @@
     "pg-hstore": "^2.3.3"
   },
   "engines": {
-    "node": "18.x"
+    "node": "24.x"
   }
 }

--- a/docs/server.md
+++ b/docs/server.md
@@ -14,7 +14,7 @@ alt="Screenshot of the Lighthouse CI server diff UI" width="48%">
 
 The LHCI server can be run in any node environment with persistent disk storage or network access to a postgres/mysql database.
 
-- Node v16 LTS
+- Node v18 LTS or later
 - Database Storage (sqlite, mysql, or postgresql)
 
 ### General

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -80,7 +80,7 @@ The team does not have the bandwidth to assist with debugging this problem. Plea
 
 ## Running LHCI in Github Actions I constantly get Ancestor hash not determinable
 
-If you are using `actions/checkout@v3` to checkout your repository and based on the size and traffic on your repo this error might happen due to how the checkout action is configured and is not a LHCI issue.
+If you are using `actions/checkout@v6` to checkout your repository and based on the size and traffic on your repo this error might happen due to how the checkout action is configured and is not a LHCI issue.
 
 Checkout action by default doesn't clone the entire repo and the number of commits to fetch is set to 1 for performance reasons. When LHCI runs the health check the ancestor hash might be missing because the branch / hash is not there in the local history.
 
@@ -93,13 +93,13 @@ jobs:
     name: Lighthouse
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 20
       - name: Fetch base_ref HEAD to use it as Ancestor hash in LHCI
         run: git fetch --depth=1 origin +refs/heads/${{github.base_ref}}:refs/remotes/origin/${{github.base_ref}}
 ```
 
-The additions are `fetch-depth: 20` added to `actions/checkout@v3` and a new step to fetch base_ref HEAD to use it as ancestor hash in LHCI.
+The additions are `fetch-depth: 20` added to `actions/checkout@v6` and a new step to fetch base_ref HEAD to use it as ancestor hash in LHCI.
 
 The fetch depth set to 20 is a good default, but might not work in all cases, you can adjust it based on your needs.


### PR DESCRIPTION
This PR does a number of updates to modernize the recommendations:
- It adds a section about using automatic GitHub tokens to the "Getting Started" guide. This is generally easier and more secure than GitHub Apps. Over the years GitHub has changed what permissions are available to this token, and they now have a `statuses` option.
- It updates all the GitHub `actions/*` actions to their latest versions. This is done on the README, the "Getting Started" page, and the actual GHA workflows.
- It updates all Node.js references to version 24.x. This includes updates to the GHA actions, docs, and recipe folders. Node 18 is deprecated now, so we should switch to a current engine. If `lhci` has any issues with this version, I'm hoping they'll be surfaced through the CI checks

I did a basic test of these changes through a minimal PoC, which you can find here: https://github.com/terrabitz/lighthouse-ci-poc/pull/1. In the PR, you can see that a status check was successfully created:

<img width="2044" height="798" alt="image" src="https://github.com/user-attachments/assets/0e77cbef-4f7e-4ad1-9b57-530ac355efb3" />

## Implementation notes

- For the example code, I used a diff block since I personally like to see the highlighted changes when it comes to a smaller modification on a larger block. Downside is it makes it less copy-pastable. I'm open to suggestions

- Although the GitHub actions updates are technically semver breaking changes, they should be backwards-compatible; the only major difference is what Node engine version is used to precompile them. I personally have never had an issue during these upgrades.

- I opted to do all these changes together for ease, but please let me know if you want these changes broken up. I'd be happy to split them if that lowers the blast radius.

- This PR should cover https://github.com/GoogleChrome/lighthouse-ci/pull/1111

- I have updated Node references in each CI provider's "Getting Started" section, but the only one I've personally tested is GHA. I don't have a good setup to test each of the other providers. I'm hoping because it's just image updates, it shouldn't break anything.
