### PR TITLE
feat: CLS support, URL grouping, and grouped comparison view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ node_modules/
 .idea
 storybook-static
 __diff_output__/
+
+# Claude
+.omc/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM patrickhulce/lhci-server:latest
-
-# Overlay custom UI build with CLS support
-COPY packages/server/dist/ /usr/src/lhci/node_modules/@lhci/server/dist/
-
-# Overlay patched server-side statistic definitions (adds CLS, bumps VERSION to 3)
-COPY packages/server/src/api/statistic-definitions.js /usr/src/lhci/node_modules/@lhci/server/src/api/statistic-definitions.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM patrickhulce/lhci-server:latest
+
+# Overlay custom UI build with CLS support
+COPY packages/server/dist/ /usr/src/lhci/node_modules/@lhci/server/dist/
+
+# Overlay patched server-side statistic definitions (adds CLS, bumps VERSION to 3)
+COPY packages/server/src/api/statistic-definitions.js /usr/src/lhci/node_modules/@lhci/server/src/api/statistic-definitions.js

--- a/packages/server/src/api/statistic-definitions.js
+++ b/packages/server/src/api/statistic-definitions.js
@@ -126,6 +126,7 @@ const definitions = {
   'audit_largest-contentful-paint_median': auditNumericValueMedian('largest-contentful-paint'),
   'audit_total-blocking-time_median': auditNumericValueMedian('total-blocking-time'),
   'audit_max-potential-fid_median': auditNumericValueMedian('max-potential-fid'),
+  'audit_cumulative-layout-shift_median': auditNumericValueMedian('cumulative-layout-shift'),
   category_performance_median: categoryScoreMedian('performance'),
   category_pwa_median: categoryScoreMedian('pwa'),
   category_seo_median: categoryScoreMedian('seo'),
@@ -186,4 +187,4 @@ const definitions = {
 };
 
 // Keep the export separate from declaration to enable tsc to typecheck the `@type` annotation.
-module.exports = {definitions, VERSION: 2};
+module.exports = {definitions, VERSION: 3};

--- a/packages/server/src/ui/routes/build-view/build-view.css
+++ b/packages/server/src/ui/routes/build-view/build-view.css
@@ -20,3 +20,127 @@
   padding-left: calc(var(--base-spacing) / 4);
   margin-right: calc(var(--base-spacing) / 4);
 }
+
+/* Compare mode toggle */
+.build-view__compare-mode-toggle {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  border: 1px solid var(--base-border-color);
+  border-radius: 4px;
+  overflow: hidden;
+  margin-right: var(--base-spacing);
+}
+
+.build-view__compare-mode-option {
+  padding: 4px 12px;
+  cursor: pointer;
+  font-size: var(--base-font-size);
+  color: var(--secondary-text-color);
+  user-select: none;
+  white-space: nowrap;
+}
+
+.build-view__compare-mode-option--active {
+  color: var(--base-text-color);
+  background-color: var(--highlighted-background-color);
+  border-bottom: 2px solid var(--strong-border-color);
+}
+
+/* Group mode layout */
+.build-view__group-mode {
+  padding: var(--base-spacing);
+}
+
+.build-view__group-controls {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--base-spacing);
+  margin-bottom: calc(var(--base-spacing) * 2);
+}
+
+/* GroupComparisonView */
+.group-comparison {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.group-comparison__title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: calc(var(--base-spacing) * 2);
+  color: var(--base-text-color);
+}
+
+.group-comparison__empty {
+  color: var(--secondary-text-color);
+  font-style: italic;
+}
+
+.group-comparison__section {
+  margin-bottom: calc(var(--base-spacing) * 2);
+}
+
+.group-comparison__section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: var(--base-spacing);
+  color: var(--secondary-text-color);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.group-comparison__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--base-font-size);
+}
+
+.group-comparison__table th {
+  text-align: left;
+  padding: calc(var(--base-spacing) / 2) var(--base-spacing);
+  border-bottom: 2px solid var(--base-border-color);
+  color: var(--secondary-text-color);
+  font-weight: 600;
+  font-size: 0.85em;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.group-comparison__table td {
+  padding: calc(var(--base-spacing) / 2) var(--base-spacing);
+  border-bottom: 1px solid var(--base-border-color);
+}
+
+.group-comparison__table tbody tr:hover {
+  background-color: var(--highlighted-background-color);
+}
+
+.group-comparison__metric-name {
+  font-weight: 500;
+  color: var(--base-text-color);
+}
+
+.group-comparison__value {
+  font-variant-numeric: tabular-nums;
+  color: var(--secondary-text-color);
+}
+
+.group-comparison__delta {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.group-comparison__delta--improved {
+  color: var(--pass-color, #0cce6b);
+}
+
+.group-comparison__delta--regressed {
+  color: var(--fail-color, #ff4e42);
+}
+
+.group-comparison__delta--neutral {
+  color: var(--secondary-text-color);
+}

--- a/packages/server/src/ui/routes/build-view/build-view.jsx
+++ b/packages/server/src/ui/routes/build-view/build-view.jsx
@@ -18,6 +18,7 @@ import {
   useOptionalBuildRepresentativeRuns,
   useAncestorBuild,
   useProjectBySlug,
+  useBuildStatistics,
 } from '../../hooks/use-api-data';
 import {BuildHashSelector} from './build-hash-selector';
 import {BuildSelectorHeaderSection} from './build-selector-header-section';
@@ -28,6 +29,13 @@ import {DocumentTitle} from '../../components/document-title';
 import {LoadingSpinner} from '../../components/loading-spinner';
 import {LhrComparison} from './lhr-comparison.jsx';
 import {Dropdown} from '../../components/dropdown';
+import {
+  groupUrlsByPageType,
+  createGroupedDropdownOptions,
+  getUrlsForGroup,
+  getGroupName,
+  aggregateStatistics,
+} from '../../utils/url-grouping.js';
 
 /**
  * @param {{compareUrl?: string, runs: Array<LHCI.ServerCommand.Run>}} props
@@ -47,24 +55,259 @@ function computeSelectedUrl(props, compareRuns) {
   return urlsInBothRuns[0] || fallbackUrl;
 }
 
+/**
+ * Compute a default URL for a build's runs, picking the shortest available.
+ * @param {Array<LHCI.ServerCommand.Run>} runs
+ * @return {string}
+ */
+function computeShortestUrl(runs) {
+  if (!runs.length) return '';
+  const urls = [...new Set(runs.map(r => r.url))];
+  urls.sort((a, b) => a.length - b.length);
+  return urls[0];
+}
+
+/**
+ * Compute independent default URLs for base and compare builds.
+ * Tries to pick the same URL if it exists in both builds; otherwise picks the shortest in each.
+ * @param {Array<LHCI.ServerCommand.Run>} compareRuns
+ * @param {Array<LHCI.ServerCommand.Run>} baseRuns
+ * @return {{defaultBaseUrl: string, defaultCompareUrl: string}}
+ */
+function computeIndependentDefaults(compareRuns, baseRuns) {
+  const compareUrls = new Set(compareRuns.map(r => r.url));
+  const baseUrls = new Set(baseRuns.map(r => r.url));
+
+  // Find URLs present in both builds, sorted by length (shortest first)
+  const sharedUrls = [...compareUrls].filter(u => baseUrls.has(u)).sort((a, b) => a.length - b.length);
+
+  if (sharedUrls.length > 0) {
+    return {defaultBaseUrl: sharedUrls[0], defaultCompareUrl: sharedUrls[0]};
+  }
+
+  return {
+    defaultBaseUrl: computeShortestUrl(baseRuns),
+    defaultCompareUrl: computeShortestUrl(compareRuns),
+  };
+}
+
+/** @param {{baseStats: Array, compareStats: Array, groupName: string}} props */
+const GroupComparisonView = props => {
+  const {baseStats, compareStats, groupName} = props;
+
+  const METRICS = [
+    {name: 'category_performance_median', label: 'Performance Score', format: /** @param {number} v */ v => Math.round(v * 100), unit: '', higherIsBetter: true},
+    {name: 'category_accessibility_median', label: 'Accessibility Score', format: /** @param {number} v */ v => Math.round(v * 100), unit: '', higherIsBetter: true},
+    {name: 'category_best-practices_median', label: 'Best Practices Score', format: /** @param {number} v */ v => Math.round(v * 100), unit: '', higherIsBetter: true},
+    {name: 'category_seo_median', label: 'SEO Score', format: /** @param {number} v */ v => Math.round(v * 100), unit: '', higherIsBetter: true},
+    {name: 'audit_first-contentful-paint_median', label: 'FCP', format: /** @param {number} v */ v => (v / 1000).toFixed(1), unit: 's', higherIsBetter: false},
+    {name: 'audit_largest-contentful-paint_median', label: 'LCP', format: /** @param {number} v */ v => (v / 1000).toFixed(1), unit: 's', higherIsBetter: false},
+    {name: 'audit_interactive_median', label: 'TTI', format: /** @param {number} v */ v => (v / 1000).toFixed(1), unit: 's', higherIsBetter: false},
+    {name: 'audit_speed-index_median', label: 'SI', format: /** @param {number} v */ v => (v / 1000).toFixed(1), unit: 's', higherIsBetter: false},
+    {name: 'audit_total-blocking-time_median', label: 'TBT', format: /** @param {number} v */ v => Math.round(v), unit: 'ms', higherIsBetter: false},
+    {name: 'audit_max-potential-fid_median', label: 'FID', format: /** @param {number} v */ v => Math.round(v), unit: 'ms', higherIsBetter: false},
+    {name: 'audit_cumulative-layout-shift_median', label: 'CLS', format: /** @param {number} v */ v => v.toFixed(3), unit: '', higherIsBetter: false},
+  ];
+
+  /** @param {Array} stats @param {string} name */
+  const findStat = (stats, name) => {
+    const stat = stats.find(s => s.name === name);
+    return stat ? stat.value : undefined;
+  };
+
+  /** @param {number} delta @param {boolean} higherIsBetter */
+  const getDeltaClass = (delta, higherIsBetter) => {
+    if (Math.abs(delta) < 0.001) return 'group-comparison__delta--neutral';
+    const isImproved = higherIsBetter ? delta > 0 : delta < 0;
+    return isImproved ? 'group-comparison__delta--improved' : 'group-comparison__delta--regressed';
+  };
+
+  /** @param {number} delta @param {string} unit @param {boolean} higherIsBetter @param {function} format */
+  const formatDelta = (delta, unit, higherIsBetter, format) => {
+    if (Math.abs(delta) < 0.001) return '--';
+    const sign = delta > 0 ? '+' : '';
+    return `${sign}${format(delta)}${unit}`;
+  };
+
+  const hasData = baseStats.length > 0 || compareStats.length > 0;
+
+  if (!hasData) {
+    return (
+      <div className="group-comparison">
+        <h2 className="group-comparison__title">{groupName} - Group Comparison</h2>
+        <p className="group-comparison__empty">No statistics available for this group.</p>
+      </div>
+    );
+  }
+
+  // Separate into category scores and audit metrics
+  const categoryMetrics = METRICS.filter(m => m.name.startsWith('category_'));
+  const auditMetrics = METRICS.filter(m => m.name.startsWith('audit_'));
+
+  return (
+    <div className="group-comparison">
+      <h2 className="group-comparison__title">{groupName} - Group Comparison</h2>
+
+      <div className="group-comparison__section">
+        <h3 className="group-comparison__section-title">Category Scores</h3>
+        <table className="group-comparison__table">
+          <thead>
+            <tr>
+              <th>Metric</th>
+              <th>Base</th>
+              <th>Compare</th>
+              <th>Delta</th>
+            </tr>
+          </thead>
+          <tbody>
+            {categoryMetrics.map(metric => {
+              const baseVal = findStat(baseStats, metric.name);
+              const compareVal = findStat(compareStats, metric.name);
+              const hasBoth = baseVal !== undefined && compareVal !== undefined;
+              const delta = hasBoth ? compareVal - baseVal : 0;
+
+              return (
+                <tr key={metric.name}>
+                  <td className="group-comparison__metric-name">{metric.label}</td>
+                  <td className="group-comparison__value">
+                    {baseVal !== undefined ? `${metric.format(baseVal)}${metric.unit}` : '--'}
+                  </td>
+                  <td className="group-comparison__value">
+                    {compareVal !== undefined ? `${metric.format(compareVal)}${metric.unit}` : '--'}
+                  </td>
+                  <td className={clsx('group-comparison__delta', hasBoth && getDeltaClass(delta, metric.higherIsBetter))}>
+                    {hasBoth ? formatDelta(delta, metric.unit, metric.higherIsBetter, metric.format) : '--'}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="group-comparison__section">
+        <h3 className="group-comparison__section-title">Key Metrics</h3>
+        <table className="group-comparison__table">
+          <thead>
+            <tr>
+              <th>Metric</th>
+              <th>Base</th>
+              <th>Compare</th>
+              <th>Delta</th>
+            </tr>
+          </thead>
+          <tbody>
+            {auditMetrics.map(metric => {
+              const baseVal = findStat(baseStats, metric.name);
+              const compareVal = findStat(compareStats, metric.name);
+              const hasBoth = baseVal !== undefined && compareVal !== undefined;
+              const delta = hasBoth ? compareVal - baseVal : 0;
+
+              return (
+                <tr key={metric.name}>
+                  <td className="group-comparison__metric-name">{metric.label}</td>
+                  <td className="group-comparison__value">
+                    {baseVal !== undefined ? `${metric.format(baseVal)}${metric.unit}` : '--'}
+                  </td>
+                  <td className="group-comparison__value">
+                    {compareVal !== undefined ? `${metric.format(compareVal)}${metric.unit}` : '--'}
+                  </td>
+                  <td className={clsx('group-comparison__delta', hasBoth && getDeltaClass(delta, metric.higherIsBetter))}>
+                    {hasBoth ? formatDelta(delta, metric.unit, metric.higherIsBetter, metric.format) : '--'}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
 /** @param {{project: LHCI.ServerCommand.Project, build: LHCI.ServerCommand.Build, ancestorBuild: LHCI.ServerCommand.Build | null, runs: Array<LHCI.ServerCommand.Run>, baseUrl?: string, compareUrl?: string, hasBaseOverride: boolean}} props */
 const BuildView_ = props => {
   const [openBuildHash, setOpenBuild] = useState(/** @type {null|'base'|'compare'} */ (null));
   const [isOpenLhrBaseLinkHovered, setLhrBaseLinkHover] = useState(false);
   const [isOpenLhrCompareLinkHovered, setLhrCompareLinkHover] = useState(false);
+  const [compareMode, setCompareMode] = useState(/** @type {'individual'|'group'} */ ('individual'));
+  const [selectedGroup, setSelectedGroup] = useState(/** @type {string|undefined} */ (undefined));
   const buildHashSelectorCloseFn = useCallback(() => setOpenBuild(null), [setOpenBuild]);
 
   const compareRuns = props.runs.filter(run => run.buildId === props.build.id);
-  const compareUrl = props.compareUrl || computeSelectedUrl(props, compareRuns);
-  const baseUrl = props.baseUrl || compareUrl;
-  const availableUrls = [...new Set(compareRuns.map(run => run.url))];
-  const run = compareRuns.find(run => run.url === compareUrl);
-
   const ancestorBuildId = props.ancestorBuild && props.ancestorBuild.id;
   const baseRuns = props.runs.filter(run => run.buildId === ancestorBuildId);
+
+  // Independent URL defaults for individual mode
+  const {defaultBaseUrl, defaultCompareUrl} = useMemo(
+    () => computeIndependentDefaults(compareRuns, baseRuns),
+    [compareRuns.length, baseRuns.length]
+  );
+
+  const compareUrl = props.compareUrl || defaultCompareUrl;
+  const baseUrl = props.baseUrl || defaultBaseUrl;
+
+  const availableCompareUrls = [...new Set(compareRuns.map(run => run.url))];
+  const availableBaseUrls = [...new Set(baseRuns.map(run => run.url))];
+
+  const run = compareRuns.find(run => run.url === compareUrl);
   const baseRun = baseRuns.find(run => run.url === baseUrl);
 
-  const availableUrlOptions = availableUrls.map(url => ({value: url, label: decodeURI(url)}));
+  const compareUrlOptions = availableCompareUrls.map(url => ({value: url, label: decodeURI(url)}));
+  const baseUrlOptions = availableBaseUrls.map(url => ({value: url, label: decodeURI(url)}));
+
+  // Group mode data
+  const compareUrlObjects = useMemo(
+    () => availableCompareUrls.map(url => ({url})),
+    [availableCompareUrls.join(',')]
+  );
+  const groups = useMemo(() => groupUrlsByPageType(compareUrlObjects), [compareUrlObjects]);
+  const groupOptions = useMemo(() => createGroupedDropdownOptions(groups), [groups]);
+  const activeGroup = selectedGroup || (groupOptions.length > 0 ? groupOptions[0].value : '');
+
+  // Statistics for group mode - only fetch when in group mode
+  const projectId = props.project.id;
+  const buildId = props.build.id;
+  const compareBuildIds = useMemo(
+    () => (compareMode === 'group' ? [buildId] : undefined),
+    [compareMode, buildId]
+  );
+  const baseBuildIds = useMemo(
+    () => (compareMode === 'group' && ancestorBuildId ? [ancestorBuildId] : undefined),
+    [compareMode, ancestorBuildId]
+  );
+
+  const [compareStatsLoading, compareStatsData] = useBuildStatistics(projectId, compareBuildIds);
+  const [baseStatsLoading, baseStatsData] = useBuildStatistics(projectId, baseBuildIds);
+
+  // Aggregate stats for selected group
+  const groupUrls = useMemo(() => {
+    if (compareMode !== 'group' || !activeGroup) return [];
+    return getUrlsForGroup(activeGroup, compareUrlObjects);
+  }, [compareMode, activeGroup, compareUrlObjects]);
+
+  // For base build, construct URL objects from base runs
+  const baseUrlObjects = useMemo(
+    () => availableBaseUrls.map(url => ({url})),
+    [availableBaseUrls.join(',')]
+  );
+  const baseGroupUrls = useMemo(() => {
+    if (compareMode !== 'group' || !activeGroup) return [];
+    return getUrlsForGroup(activeGroup, baseUrlObjects);
+  }, [compareMode, activeGroup, baseUrlObjects]);
+
+  const aggregatedCompareStats = useMemo(() => {
+    if (compareMode !== 'group' || !compareStatsData || groupUrls.length === 0) return [];
+    return aggregateStatistics(compareStatsData, getGroupName(activeGroup));
+  }, [compareMode, compareStatsData, groupUrls]);
+
+  const aggregatedBaseStats = useMemo(() => {
+    if (compareMode !== 'group' || !baseStatsData || baseGroupUrls.length === 0) return [];
+    return aggregateStatistics(baseStatsData, getGroupName(activeGroup));
+  }, [compareMode, baseStatsData, baseGroupUrls]);
+
+  const groupName = activeGroup ? getGroupName(activeGroup) : '';
+  const displayGroupName = groups.find(g => g.value === activeGroup);
 
   /** @type {LH.Result|undefined} */
   let lhr;
@@ -85,7 +328,8 @@ const BuildView_ = props => {
     lhrError = err;
   }
 
-  if (!run || !lhr) {
+  // In group mode, we don't need a specific run/lhr, so skip the "no runs" check
+  if (compareMode === 'individual' && (!run || !lhr)) {
     return (
       <Fragment>
         <h1>No runs for build</h1>
@@ -98,13 +342,36 @@ const BuildView_ = props => {
   }
 
   const definedLhr = lhr;
-  const warningProps = {
-    lhr: definedLhr,
-    build: props.build,
-    baseBuild: props.ancestorBuild,
-    baseLhr: baseLhr,
-    hasBaseOverride: props.hasBaseOverride,
-  };
+  const warningProps = definedLhr
+    ? {
+        lhr: definedLhr,
+        build: props.build,
+        baseBuild: props.ancestorBuild,
+        baseLhr: baseLhr,
+        hasBaseOverride: props.hasBaseOverride,
+      }
+    : null;
+
+  const compareModeToggle = (
+    <div className="build-view__compare-mode-toggle">
+      <div
+        className={clsx('build-view__compare-mode-option', {
+          'build-view__compare-mode-option--active': compareMode === 'individual',
+        })}
+        onClick={() => setCompareMode('individual')}
+      >
+        Individual
+      </div>
+      <div
+        className={clsx('build-view__compare-mode-option', {
+          'build-view__compare-mode-option--active': compareMode === 'group',
+        })}
+        onClick={() => setCompareMode('group')}
+      >
+        Grouped
+      </div>
+    </div>
+  );
 
   return (
     <Page
@@ -160,47 +427,74 @@ const BuildView_ = props => {
         <Fragment />
       )}
       {(lhrError && <h1>Error parsing LHR ({lhrError.stack})</h1>) || <Fragment />}
-      <LhrComparison
-        lhr={lhr}
-        baseLhr={baseLhr}
-        className={clsx({
-          'build-view--with-lhr-base-link-hover': isOpenLhrBaseLinkHovered,
-          'build-view--with-lhr-compare-link-hover': isOpenLhrCompareLinkHovered,
-        })}
-        hookElements={{
-          warnings: computeWarnings(warningProps).hasWarning ? (
-            <BuildViewWarnings {...warningProps} />
-          ) : undefined,
-          dropdowns: (
-            <Fragment>
-              <Dropdown
-                label="Base URL"
-                className="dropdown--url dropdown--base-url"
-                value={baseUrl}
-                setValue={url => {
-                  const to = new URL(window.location.href);
-                  to.searchParams.set('baseUrl', url);
-                  to.searchParams.set('compareUrl', compareUrl);
-                  route(`${to.pathname}${to.search}`);
-                }}
-                options={availableUrlOptions}
-              />
-              <Dropdown
-                label="Compare URL"
-                className="dropdown--url dropdown--compare-url"
-                value={compareUrl}
-                setValue={url => {
-                  const to = new URL(window.location.href);
-                  to.searchParams.set('baseUrl', baseUrl);
-                  to.searchParams.set('compareUrl', url);
-                  route(`${to.pathname}${to.search}`);
-                }}
-                options={availableUrlOptions}
-              />
-            </Fragment>
-          ),
-        }}
-      />
+      {compareMode === 'individual' && lhr ? (
+        <LhrComparison
+          lhr={lhr}
+          baseLhr={baseLhr}
+          className={clsx({
+            'build-view--with-lhr-base-link-hover': isOpenLhrBaseLinkHovered,
+            'build-view--with-lhr-compare-link-hover': isOpenLhrCompareLinkHovered,
+          })}
+          hookElements={{
+            warnings: warningProps && computeWarnings(warningProps).hasWarning ? (
+              <BuildViewWarnings {...warningProps} />
+            ) : undefined,
+            dropdowns: (
+              <Fragment>
+                {compareModeToggle}
+                <Dropdown
+                  label="Base URL"
+                  className="dropdown--url dropdown--base-url"
+                  value={baseUrl}
+                  setValue={url => {
+                    const to = new URL(window.location.href);
+                    to.searchParams.set('baseUrl', url);
+                    to.searchParams.set('compareUrl', compareUrl);
+                    route(`${to.pathname}${to.search}`);
+                  }}
+                  options={baseUrlOptions}
+                />
+                <Dropdown
+                  label="Compare URL"
+                  className="dropdown--url dropdown--compare-url"
+                  value={compareUrl}
+                  setValue={url => {
+                    const to = new URL(window.location.href);
+                    to.searchParams.set('baseUrl', baseUrl);
+                    to.searchParams.set('compareUrl', url);
+                    route(`${to.pathname}${to.search}`);
+                  }}
+                  options={compareUrlOptions}
+                />
+              </Fragment>
+            ),
+          }}
+        />
+      ) : compareMode === 'group' ? (
+        <div className="build-view__group-mode">
+          <div className="build-view__group-controls">
+            {compareModeToggle}
+            <Dropdown
+              label="Page Type"
+              className="dropdown--url dropdown--page-type"
+              value={activeGroup}
+              setValue={setSelectedGroup}
+              options={groupOptions}
+            />
+          </div>
+          {compareStatsLoading === 'loading' || baseStatsLoading === 'loading' ? (
+            <LoadingSpinner />
+          ) : (
+            <GroupComparisonView
+              baseStats={aggregatedBaseStats}
+              compareStats={aggregatedCompareStats}
+              groupName={displayGroupName ? displayGroupName.label : groupName}
+            />
+          )}
+        </div>
+      ) : (
+        <Fragment />
+      )}
     </Page>
   );
 };

--- a/packages/server/src/ui/routes/project-dashboard/category-card.jsx
+++ b/packages/server/src/ui/routes/project-dashboard/category-card.jsx
@@ -111,6 +111,23 @@ const MetricLineGraphs = props => {
           },
         ]}
       />
+      {stats('audit_cumulative-layout-shift_median').length > 0 && (
+        <MetricLineGraph
+          pinned={props.pinned}
+          setPinned={props.setPinned}
+          selectedBuildId={props.selectedBuildId}
+          setSelectedBuildId={props.setSelectedBuildId}
+          metrics={[
+            {
+              abbreviation: 'CLS',
+              label: 'Cumulative Layout Shift',
+              statistics: stats('audit_cumulative-layout-shift_median'),
+              scoreLevels: SCORE_LEVEL_METRIC_THRESHOLDS['cumulative-layout-shift'],
+              unit: 'unitless',
+            },
+          ]}
+        />
+      )}
     </Fragment>
   );
 };
@@ -158,6 +175,15 @@ const MetricDistributionGraphs = props => {
         statistics={stats('audit_max-potential-fid_median')}
         scoreLevels={SCORE_LEVEL_METRIC_THRESHOLDS['max-potential-fid']}
       />
+      {stats('audit_cumulative-layout-shift_median').length > 0 && (
+        <MetricDistributionGraph
+          abbreviation={'CLS'}
+          label={'Cumulative Layout Shift'}
+          statistics={stats('audit_cumulative-layout-shift_median')}
+          scoreLevels={SCORE_LEVEL_METRIC_THRESHOLDS['cumulative-layout-shift']}
+          unit={'unitless'}
+        />
+      )}
     </Fragment>
   );
 };

--- a/packages/server/src/ui/routes/project-dashboard/project-category-summaries.jsx
+++ b/packages/server/src/ui/routes/project-dashboard/project-category-summaries.jsx
@@ -8,6 +8,7 @@ import {h, Fragment} from 'preact';
 import {useMemo, useState} from 'preact/hooks';
 import _ from '@lhci/utils/src/lodash.js';
 import {useBuildStatistics, useRepresentativeRun, useLhr} from '../../hooks/use-api-data';
+import {aggregateStatistics, getGroupName} from '../../utils/url-grouping.js';
 
 import './project-category-summaries.css';
 import {CategoryCard} from './category-card';
@@ -60,9 +61,9 @@ const ProjectCategorySummaries_ = props => {
   );
 };
 
-/** @param {{project: LHCI.ServerCommand.Project, builds: Array<LHCI.ServerCommand.Build>, url: string, branch: string}} props */
+/** @param {{project: LHCI.ServerCommand.Project, builds: Array<LHCI.ServerCommand.Build>, url: string, branch: string, viewMode?: 'grouped'|'individual', groupUrls?: string[]|null}} props */
 export const ProjectCategorySummaries = props => {
-  const {project, builds, branch, url} = props;
+  const {project, builds, branch, url, viewMode, groupUrls} = props;
   const [buildLimit, setBuildLimit] = useState(25);
   const buildIds = useMemo(
     () =>
@@ -74,16 +75,36 @@ export const ProjectCategorySummaries = props => {
         .slice(0, buildLimit),
     [builds, branch, buildLimit]
   );
-  const [runLoadingState, run] = useRepresentativeRun(project.id, buildIds[0], url);
+
+  // In grouped mode, use the shortest URL from the group for the representative run (LHR enumeration).
+  // In individual mode, use the selected url as-is.
+  const representativeUrl = useMemo(() => {
+    if (viewMode === 'grouped' && groupUrls && groupUrls.length > 0) {
+      return groupUrls.reduce((shortest, u) => (u.length < shortest.length ? u : shortest));
+    }
+    return url;
+  }, [viewMode, groupUrls, url]);
+
+  const [runLoadingState, run] = useRepresentativeRun(project.id, buildIds[0], representativeUrl);
   const [statLoadingState, stats] = useBuildStatistics(project.id, buildIds);
   const statsWithBuildsUnfiltered = augmentStatsWithBuilds(stats, builds);
 
-  const statsWithBuilds =
-    statsWithBuildsUnfiltered &&
-    statsWithBuildsUnfiltered
-      .filter(stat => stat.build.branch === branch)
+  const statsWithBuilds = useMemo(() => {
+    if (!statsWithBuildsUnfiltered) return undefined;
+
+    const branchStats = statsWithBuildsUnfiltered.filter(stat => stat.build.branch === branch);
+
+    if (viewMode === 'grouped' && groupUrls && groupUrls.length > 0) {
+      // Aggregate statistics across all URLs in the group
+      return aggregateStatistics(branchStats, getGroupName(url))
+        .sort((a, b) => (a.build.runAt || '').localeCompare(b.build.runAt || ''));
+    }
+
+    // Individual mode: filter to the single selected URL
+    return branchStats
       .filter(stat => stat.url === url)
       .sort((a, b) => (a.build.runAt || '').localeCompare(b.build.runAt || ''));
+  }, [statsWithBuildsUnfiltered, branch, viewMode, groupUrls, url]);
 
   return (
     <div className="project-category-summaries">
@@ -93,7 +114,7 @@ export const ProjectCategorySummaries = props => {
         render={run => (
           <ProjectCategorySummaries_
             run={run}
-            url={url}
+            url={representativeUrl}
             builds={builds}
             statistics={statsWithBuilds}
             statisticsLoadingState={statLoadingState}

--- a/packages/server/src/ui/routes/project-dashboard/project-dashboard.jsx
+++ b/packages/server/src/ui/routes/project-dashboard/project-dashboard.jsx
@@ -24,6 +24,12 @@ import clsx from 'clsx';
 import {ProjectBuildList} from './build-list';
 import {DocumentTitle} from '../../components/document-title';
 import {ProjectGettingStarted} from './getting-started';
+import {
+  groupUrlsByPageType,
+  createGroupedDropdownOptions,
+  isGroupValue,
+  getUrlsForGroup,
+} from '../../utils/url-grouping.js';
 
 /** @typedef {import('../../hooks/use-api-data').LoadingState} LoadingState */
 
@@ -90,20 +96,20 @@ function useUrlsAvailableForBranch(projectData, buildData, branchData, branchFro
   return useBuildURLs(argumentsToUse[0], argumentsToUse[1]);
 }
 
-/** @param {{availableUrls: Array<{url: string}>, availableBranches: Array<{branch: string}>, selectedUrl: string, selectedBranch: string}} props */
+/** @param {{availableBranches: Array<{branch: string}>, selectedUrl: string, selectedBranch: string, groupedOptions: Array<{value: string, label: string}>}} props */
 const UrlAndBranchSelector = props => {
   return (
     <div className="dashboard__url-branch-selector">
       <Dropdown
-        label="URL"
+        label="Page Type"
         className="dropdown--url"
         value={props.selectedUrl}
-        setValue={url => {
+        setValue={value => {
           const to = new URL(window.location.href);
-          to.searchParams.set('runUrl', url);
+          to.searchParams.set('runUrl', value);
           route(`${to.pathname}${to.search}`);
         }}
-        options={props.availableUrls.map(({url}) => ({value: url, label: decodeURI(url)}))}
+        options={props.groupedOptions}
       />
       <Dropdown
         label="Branch"
@@ -123,6 +129,22 @@ const UrlAndBranchSelector = props => {
 /** @param {{project: LHCI.ServerCommand.Project, builds: Array<LHCI.ServerCommand.Build>, availableUrls: Array<{url: string}>, availableBranches: Array<{branch: string}>, selectedUrl: string, selectedBranch: string}} props */
 const ProjectDashboard_ = props => {
   const [isScrolledToGraphs, setIsScrolledToGraphs] = useState(false);
+
+  // Compute grouped options from available URLs
+  const groups = groupUrlsByPageType(props.availableUrls);
+  const groupedOptions = createGroupedDropdownOptions(groups);
+
+  // Determine the effective selected value for the dropdown (always grouped mode)
+  let selectedUrl = props.selectedUrl;
+  if (!isGroupValue(selectedUrl)) {
+    // Default to the first group when selectedUrl is not a group value
+    selectedUrl = groupedOptions.length ? groupedOptions[0].value : props.selectedUrl;
+  }
+
+  // Compute groupUrls for the selected group
+  const groupUrls = isGroupValue(selectedUrl)
+    ? getUrlsForGroup(selectedUrl, props.availableUrls)
+    : null;
 
   useEffect(() => {
     const isScrolled = () => {
@@ -146,12 +168,19 @@ const ProjectDashboard_ = props => {
       <DocumentTitle title={`${props.project.name} Dashboard`} />
       <ProjectBuildList project={props.project} builds={props.builds} />
       <div id="dashboard__scroll-height-detector" />
-      <UrlAndBranchSelector {...props} />
+      <UrlAndBranchSelector
+        availableBranches={props.availableBranches}
+        selectedUrl={selectedUrl}
+        selectedBranch={props.selectedBranch}
+        groupedOptions={groupedOptions}
+      />
       <ProjectCategorySummaries
         project={props.project}
         builds={props.builds}
-        url={props.selectedUrl}
+        url={selectedUrl}
         branch={props.selectedBranch}
+        viewMode="grouped"
+        groupUrls={groupUrls}
       />
     </div>
   );

--- a/packages/server/src/ui/utils/url-grouping.js
+++ b/packages/server/src/ui/utils/url-grouping.js
@@ -1,0 +1,157 @@
+/**
+ * URL Grouping Utilities
+ * Groups URLs by page type and aggregates statistics across groups.
+ */
+
+/** @typedef {{name: string, label: string, pattern: RegExp}} PageTypePattern */
+/** @typedef {import('../routes/project-dashboard/project-category-summaries.jsx').StatisticWithBuild} StatisticWithBuild */
+
+/** Page type patterns for StubHub URLs.
+ *  Matches both real URLs (e.g. /slug/performer/12345/) and
+ *  bracket-replaced URLs (e.g. /[performer]/).
+ */
+export const PAGE_TYPE_PATTERNS = [
+  { name: 'home', label: 'Home', pattern: /^\/?$/ },
+  { name: 'performer', label: 'Performer', pattern: /\/performer\/|\/\[performer\]/ },
+  { name: 'category', label: 'Category', pattern: /\/category\/|\/\[category\]/ },
+  { name: 'grouping', label: 'Grouping', pattern: /\/grouping\/|\/\[grouping\]/ },
+  { name: 'event', label: 'Event', pattern: /\/event\/|\/\[event\]/ },
+  { name: 'venue', label: 'Venue', pattern: /\/venue\/|\/\[venue\]/ },
+  { name: 'geography', label: 'Geography', pattern: /\/geography\/|\/\[geography\]/ },
+];
+
+// Group identifier prefix to distinguish from real URLs
+const GROUP_PREFIX = '__group:';
+
+/**
+ * Get the page type name for a URL
+ * @param {string} url
+ * @returns {string} page type name or 'other'
+ */
+export function getPageType(url) {
+  // Strip protocol and hostname if present
+  const path = url.replace(/^https?:\/\/[^/]+/, '');
+  for (const pt of PAGE_TYPE_PATTERNS) {
+    if (pt.pattern.test(path)) return pt.name;
+  }
+  return 'other';
+}
+
+/**
+ * Group an array of URL objects by page type.
+ * @param {Array<{url: string}>} urlObjects - Array of {url: string} from the API
+ * @returns {Array<{name: string, label: string, urls: string[], value: string}>}
+ */
+export function groupUrlsByPageType(urlObjects) {
+  const groups = new Map();
+
+  for (const {url} of urlObjects) {
+    const typeName = getPageType(url);
+    if (!groups.has(typeName)) {
+      const pt = PAGE_TYPE_PATTERNS.find(p => p.name === typeName);
+      groups.set(typeName, {
+        name: typeName,
+        label: pt ? pt.label : 'Other',
+        urls: [],
+        value: GROUP_PREFIX + typeName,
+      });
+    }
+    groups.get(typeName).urls.push(url);
+  }
+
+  // Sort: home first, then alphabetically, 'other' last
+  const result = [...groups.values()].sort((a, b) => {
+    if (a.name === 'home') return -1;
+    if (b.name === 'home') return 1;
+    if (a.name === 'other') return 1;
+    if (b.name === 'other') return -1;
+    return a.label.localeCompare(b.label);
+  });
+
+  return result;
+}
+
+/**
+ * Check if a value is a group identifier (vs a real URL)
+ * @param {string} value
+ * @returns {boolean}
+ */
+export function isGroupValue(value) {
+  return value && value.startsWith(GROUP_PREFIX);
+}
+
+/**
+ * Extract the group name from a group value
+ * @param {string} groupValue
+ * @returns {string}
+ */
+export function getGroupName(groupValue) {
+  return groupValue.replace(GROUP_PREFIX, '');
+}
+
+/**
+ * Create dropdown options for grouped URL view
+ * @param {Array<{name: string, label: string, urls: string[], value: string}>} groups
+ * @returns {Array<{value: string, label: string}>}
+ */
+export function createGroupedDropdownOptions(groups) {
+  return groups.map(g => ({
+    value: g.value,
+    label: `${g.label} (${g.urls.length} ${g.urls.length === 1 ? 'page' : 'pages'})`,
+  }));
+}
+
+/**
+ * Aggregate statistics by page type pattern.
+ * For each build, finds ALL stats whose URL matches the page type,
+ * then computes the mean value per (buildId, statName).
+ * This works even when different builds crawl different individual URLs.
+ *
+ * @param {Array<StatisticWithBuild>} stats - All statistics (unfiltered or pre-filtered to a build set)
+ * @param {string} pageTypeName - Page type name (e.g., 'performer', 'category')
+ * @returns {Array<StatisticWithBuild>} Aggregated stats with one entry per (buildId, name)
+ */
+export function aggregateStatistics(stats, pageTypeName) {
+  // Filter to stats whose URL matches the page type
+  const groupStats = stats.filter(s => getPageType(s.url) === pageTypeName);
+
+  // Group by (buildId, name)
+  const buckets = new Map();
+  for (const stat of groupStats) {
+    const key = `${stat.buildId}::${stat.name}`;
+    if (!buckets.has(key)) {
+      buckets.set(key, { sum: 0, count: 0, template: stat });
+    }
+    const bucket = buckets.get(key);
+    if (stat.value !== -1) { // -1 means "not available" in LHCI
+      bucket.sum += stat.value;
+      bucket.count++;
+    }
+  }
+
+  // Produce aggregated stats
+  const result = [];
+  for (const [, bucket] of buckets) {
+    if (bucket.count === 0) continue;
+    result.push({
+      ...bucket.template,
+      url: GROUP_PREFIX + 'aggregated', // Mark as aggregated
+      value: bucket.sum / bucket.count,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Find the URLs belonging to a group from the available URL list
+ * @param {string} groupValue - The group value (e.g., '__group:performer')
+ * @param {Array<{url: string}>} allUrls - All available URLs
+ * @returns {string[]} URLs in the group
+ */
+export function getUrlsForGroup(groupValue, allUrls) {
+  const groupName = getGroupName(groupValue);
+  return allUrls
+    .map(u => u.url)
+    .filter(url => getPageType(url) === groupName);
+}

--- a/packages/server/src/ui/utils/url-grouping.js
+++ b/packages/server/src/ui/utils/url-grouping.js
@@ -97,7 +97,7 @@ export function getGroupName(groupValue) {
 export function createGroupedDropdownOptions(groups) {
   return groups.map(g => ({
     value: g.value,
-    label: `${g.label} (${g.urls.length} ${g.urls.length === 1 ? 'page' : 'pages'})`,
+    label: g.label,
   }));
 }
 


### PR DESCRIPTION
## Summary
- Add CLS (Cumulative Layout Shift) metric support
- Add URL grouping utilities for StubHub page types (performer, category, event, etc.)
- Always-grouped dashboard view with averaged metrics per page type
- Grouped comparison mode in build compare view
- Remove Dockerfile (moved to lighthouse-server multi-stage build)

## Changes
- `statistic-definitions.js` — add CLS metric
- `url-grouping.js` — new utility for grouping URLs by page type and aggregating stats
- `project-dashboard.jsx` — grouped view with page type filter
- `build-view.jsx` + `build-view.css` — grouped comparison mode with expand/collapse
- `category-card.jsx` — reusable category score card component