### PR TITLE
fix: replace uuid dependency with crypto.randomBytes

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,6 @@
     "lighthouse-logger": "1.2.0",
     "open": "^7.1.0",
     "tmp": "^0.1.0",
-    "uuid": "^8.3.1",
     "yargs": "^15.4.1",
     "yargs-parser": "^13.1.2"
   }

--- a/packages/cli/src/collect/node-runner.js
+++ b/packages/cli/src/collect/node-runner.js
@@ -8,7 +8,7 @@
 const os = require('os');
 const fs = require('fs');
 const path = require('path');
-const uuid = require('uuid');
+const {generateUUID} = require('@lhci/utils/src/uuid.js');
 const childProcess = require('child_process');
 const {getSavedReportsDirectory} = require('@lhci/utils/src/saved-reports.js');
 
@@ -62,7 +62,7 @@ class LighthouseRunner {
     const lhArgs = [url, '--output', 'json', '--output-path', 'stdout'];
 
     if (Object.keys(settings).length) {
-      const flagsFilename = `flags-${uuid.v4()}.json`;
+      const flagsFilename = `flags-${generateUUID()}.json`;
       const flagsFilePath = path.join(getSavedReportsDirectory(), flagsFilename);
       lhArgs.push('--cli-flags-path', flagsFilePath);
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,8 +31,7 @@
     "express-basic-auth": "^1.2.0",
     "morgan": "^1.9.1",
     "sequelize": "^6.35.2",
-    "umzug": "^3.4.0",
-    "uuid": "^8.3.1"
+    "umzug": "^3.4.0"
   },
   "devDependencies": {
     "clsx": "^1.0.4",

--- a/packages/server/src/api/storage/sql/sql.js
+++ b/packages/server/src/api/storage/sql/sql.js
@@ -8,7 +8,7 @@
 const path = require('path');
 const log = require('debug')('lhci:server:sql');
 const logVerbose = require('debug')('lhci:server:sql:verbose');
-const uuid = require('uuid');
+const {generateUUID} = require('@lhci/utils/src/uuid.js');
 const {Umzug, SequelizeStorage} = require('umzug');
 const {Sequelize, Op} = require('sequelize');
 const {omit, padEnd} = require('@lhci/utils/src/lodash.js');
@@ -393,13 +393,13 @@ class SqlStorageMethod {
     const {projectModel} = this._sql();
     if (typeof unsavedProject.name !== 'string') throw new E422('Project name missing');
     if (unsavedProject.name.length < 4) throw new E422('Project name too short');
-    const projectId = uuid.v4();
+    const projectId = generateUUID();
     const adminToken = generateAdminToken();
     const project = await projectModel.create({
       ...unsavedProject,
       baseBranch: unsavedProject.baseBranch || 'master',
       adminToken: hashAdminToken(adminToken, projectId),
-      token: uuid.v4(),
+      token: generateUUID(),
       id: projectId,
     });
 
@@ -474,7 +474,7 @@ class SqlStorageMethod {
     const existingForHash = await buildModel.findOne({where: existingWhere});
     if (existingForHash) throw new E422(`Build already exists for hash "${unsavedBuild.hash}"`);
 
-    const build = await buildModel.create({...unsavedBuild, id: uuid.v4()});
+    const build = await buildModel.create({...unsavedBuild, id: generateUUID()});
     return clone(this._value(build));
   }
 
@@ -689,7 +689,7 @@ class SqlStorageMethod {
     if (unsavedRun.representative) throw new E422('Invalid representative value');
     if (unsavedRun.url.length > 256) throw new E422('URL too long');
 
-    const run = await runModel.create({...unsavedRun, representative: false, id: uuid.v4()});
+    const run = await runModel.create({...unsavedRun, representative: false, id: generateUUID()});
     return clone(this._value(run));
   }
 
@@ -734,7 +734,7 @@ class SqlStorageMethod {
     } else {
       logVerbose('[_createOrUpdateStatistic] no existing statistic found, creating one');
       statistic = this._value(
-        await statisticModel.create({...unsavedStatistic, id: uuid.v4()}, {transaction})
+        await statisticModel.create({...unsavedStatistic, id: generateUUID()}, {transaction})
       );
     }
 
@@ -785,7 +785,7 @@ class SqlStorageMethod {
    */
   async _resetProjectToken(projectId) {
     const {projectModel} = this._sql();
-    const newToken = uuid.v4();
+    const newToken = generateUUID();
     await projectModel.update({token: newToken}, {where: {id: projectId}});
     return newToken;
   }

--- a/packages/utils/src/uuid.js
+++ b/packages/utils/src/uuid.js
@@ -1,0 +1,23 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const crypto = require('crypto');
+
+/**
+ * @return {string}
+ */
+function generateUUID() {
+  // RFC 4122 version 4 UUID: set version (4) and variant (10xx) bits
+  // TODO: replace with crypto.randomUUID() when minimum Node version is 19+
+  const bytes = crypto.randomBytes(16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+module.exports = {generateUUID};

--- a/yarn.lock
+++ b/yarn.lock
@@ -20354,7 +20354,7 @@ string-to-arraybuffer@^1.0.0:
     atob-lite "^2.0.0"
     is-base64 "^0.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -20379,6 +20379,15 @@ string-width@^1.0.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
@@ -20503,7 +20512,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -20537,6 +20546,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -21917,11 +21933,6 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-uuid@^8.3.1:
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
-  integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
-
 uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
@@ -22391,7 +22402,7 @@ world-calendars@^1.0.3:
   dependencies:
     object-assign "^4.1.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -22421,6 +22432,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Summary
- Removes the `uuid` package from `@lhci/cli` and `@lhci/server` to eliminate [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (moderate severity, uuid <14.0.0)
- Adds a `generateUUID()` utility in `@lhci/utils/src/uuid.js` using `crypto.randomBytes` with manual UUID v4 bit formatting
- Compatible with Node 18 (no dependency on `crypto.randomUUID` which requires Node 19+)

## Related
- #1131
- #393

## Test plan
- `yarn jest packages/server/test/api/storage/storage-method.test.js` passes
- `yarn jest packages/utils/test` passes (pre-existing failures in `build-context.test.js` are unrelated)